### PR TITLE
To black

### DIFF
--- a/.github/workflows/pythonpackage_coverage.yml
+++ b/.github/workflows/pythonpackage_coverage.yml
@@ -26,15 +26,23 @@ jobs:
     - name: Install
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest pytest-cov
+        pip install black flake8 pytest pytest-cov
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
         pip install .
+    - name: Check format with black 
+      run: |
+        black -l 79 --check .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        # our line length is 79 (72 for docstrings), and we are strict (stop) if above 88
+        flake8 . --count --select=E9,F63,F7,F82,E501 --max-line-length=88 --show-source --statistics
+        # exit-zero treats all errors as warnings.
+        # ignoring when clashing with black:
+        # - W503 line break before binary operator
+        # - E203 whitespace before ':'
+        # - C0330 Wrong hanging indentation before block
+        flake8 . --count --exit-zero --max-complexity=10 --statistics --ignore=E203,W503,C0330
     - name: Generate coverage report
       run: |
         pip install pytest

--- a/README.rst
+++ b/README.rst
@@ -117,7 +117,14 @@ Francisco Romero Ferrero (2017-)
 Contribute
 ==========
 
-Please.
+We welcome contributions. The preferred way to report problems is by creating an issue. The best way to propose changes in the code is to create a pull request. 
+
+We try to follow PEP 8 and we use an autoformatter called black to have a uniform code look. Before submitting pull requests, we would appreciate if you autoformat the code using the following command:
+
+.. code-block:: bash
+    
+    black -l 79 .
+    
 
 License
 =======

--- a/setup.py
+++ b/setup.py
@@ -1,34 +1,28 @@
-from setuptools import setup, find_packages
+from setuptools import find_packages, setup
 
 with open("README.rst", "r") as fh:
     long_description = fh.read()
 
-setup(name='trajectorytools',
-      version='0.3.1-alpha',
-      description='A tool to study 2D trajectories',
-      long_description=long_description,
-      url='http://github.com/fjhheras/trajectorytools',
-      author='Francisco J.H. Heras',
-      author_email='fjhheras@gmail.com',
-      license='GPL',
-
-      install_requires=['MiniballCpp',
-                        'matplotlib',
-                        'scikit-learn',
-                        'scipy'],
-
-      packages=find_packages(),
-      package_data={'trajectorytools': ['data/*.npy']},
-      include_package_data=True,
-      zip_safe=False,
-
-      classifiers=[
-          'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-          'Programming Language :: Python',
-          'Topic :: Scientific/Engineering',
-          'Topic :: Scientific/Engineering :: Physics',
-          'Topic :: Software Development :: Libraries',
-          'Topic :: Utilities'
-      ],
-
-      )
+setup(
+    name="trajectorytools",
+    version="0.3.1-alpha",
+    description="A tool to study 2D trajectories",
+    long_description=long_description,
+    url="http://github.com/fjhheras/trajectorytools",
+    author="Francisco J.H. Heras",
+    author_email="fjhheras@gmail.com",
+    license="GPL",
+    install_requires=["MiniballCpp", "matplotlib", "scikit-learn", "scipy"],
+    packages=find_packages(),
+    package_data={"trajectorytools": ["data/*.npy"]},
+    include_package_data=True,
+    zip_safe=False,
+    classifiers=[
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+        "Programming Language :: Python",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Scientific/Engineering :: Physics",
+        "Topic :: Software Development :: Libraries",
+        "Topic :: Utilities",
+    ],
+)

--- a/tests/collective_test.py
+++ b/tests/collective_test.py
@@ -2,16 +2,15 @@ import pytest
 import numpy as np
 
 import trajectorytools.constants as cons
-from trajectorytools.collective import (angular_momentum,
-                                        polarization)
+from trajectorytools.collective import angular_momentum, polarization
 from trajectorytools.geometry import center_in_trajectory
 import trajectorytools as tt
 
 
-class TestExtremeCases():
+class TestExtremeCases:
     def setup_class(self):
         v = np.random.randn(50, 2)
-        self.v_same = np.stack([v]*10, axis=1)
+        self.v_same = np.stack([v] * 10, axis=1)
         self.v_antiparallel = self.v_same.copy()
         self.v_antiparallel[:, ::2, :] *= -1
 
@@ -23,7 +22,7 @@ class TestExtremeCases():
         pol = tt.norm(polarization(self.v_antiparallel))
         assert pytest.approx(pol, 1e-16) == 0
 
-    @pytest.mark.parametrize('num_dims_point', [2, 1])
+    @pytest.mark.parametrize("num_dims_point", [2, 1])
     def test_ang_mom_antiparallel(self, num_dims_point):
         # Random point to measure angular momentum
         if num_dims_point == 2:
@@ -31,9 +30,10 @@ class TestExtremeCases():
         elif num_dims_point == 1:
             point = np.random.randn(50, 2)
         # Random locations (but all in the same point)
-        locations = np.stack([np.random.randn(50, 2)]*10, axis=1)
-        ang_momentum = tt.norm(angular_momentum(
-            self.v_antiparallel, locations))
+        locations = np.stack([np.random.randn(50, 2)] * 10, axis=1)
+        ang_momentum = tt.norm(
+            angular_momentum(self.v_antiparallel, locations)
+        )
         assert pytest.approx(ang_momentum, 1e-16) == 0
 
     @pytest.fixture(autouse=True)
@@ -46,7 +46,7 @@ class TestExtremeCases():
         assert np.all(v_antiparallel == self.v_antiparallel)
 
 
-class TestAngularMomentum():
+class TestAngularMomentum:
     def setup_class(self):
         self.v = np.random.randn(50, 10, 2)
         self.s = np.random.randn(50, 10, 2)
@@ -70,9 +70,8 @@ class TestAngularMomentum():
         np.testing.assert_almost_equal(L_1, L_1_b)
 
         L_2 = num_individuals * angular_momentum(
-            V[:, np.newaxis, :],
-            S[:, np.newaxis, :],
-            self.p)
+            V[:, np.newaxis, :], S[:, np.newaxis, :], self.p
+        )
 
         # angular momentum around a point is the sum of the angular
         # momentum around the center of mass and the angular momentum

--- a/tests/collective_test.py
+++ b/tests/collective_test.py
@@ -1,10 +1,10 @@
-import pytest
 import numpy as np
+import pytest
 
+import trajectorytools as tt
 import trajectorytools.constants as cons
 from trajectorytools.collective import angular_momentum, polarization
 from trajectorytools.geometry import center_in_trajectory
-import trajectorytools as tt
 
 
 class TestExtremeCases:
@@ -32,7 +32,7 @@ class TestExtremeCases:
         # Random locations (but all in the same point)
         locations = np.stack([np.random.randn(50, 2)] * 10, axis=1)
         ang_momentum = tt.norm(
-            angular_momentum(self.v_antiparallel, locations)
+            angular_momentum(self.v_antiparallel, locations, center=point)
         )
         assert pytest.approx(ang_momentum, 1e-16) == 0
 

--- a/tests/geometry_test.py
+++ b/tests/geometry_test.py
@@ -3,17 +3,23 @@ import pytest
 
 import trajectorytools as tt
 import trajectorytools.constants as cons
-from trajectorytools.geometry import (angle_between_vectors, comoving_to_fixed,
-                                      distance_travelled, fixed_to_comoving,
-                                      norm, normalise,
-                                      signed_angle_between_vectors,
-                                      straightness)
+from trajectorytools.geometry import (
+    angle_between_vectors,
+    comoving_to_fixed,
+    distance_travelled,
+    fixed_to_comoving,
+    norm,
+    normalise,
+    signed_angle_between_vectors,
+    straightness,
+)
 
 
-class TestWithStraightTrajectory():
+class TestWithStraightTrajectory:
     def setup_class(self, max_length=11):
-        t = np.load(cons.test_raw_trajectories_path,
-                    allow_pickle=True)[:max_length]
+        t = np.load(cons.test_raw_trajectories_path, allow_pickle=True)[
+            :max_length
+        ]
         tt.interpolate_nans(t)
 
         # Modifying the first individual for super-straight movement
@@ -26,15 +32,16 @@ class TestWithStraightTrajectory():
         assert distance_t.ndim == 2
         assert distance_t.shape[0] == self.t.shape[0]
         assert distance_t.shape[1] == self.t.shape[1]
-        np.testing.assert_almost_equal(distance_t[-1, 0],
-                                       (self.t.shape[0] - 1) * np.sqrt(2))
+        np.testing.assert_almost_equal(
+            distance_t[-1, 0], (self.t.shape[0] - 1) * np.sqrt(2)
+        )
 
     def test_straightness(self):
         straight = straightness(self.t)
         assert straight.ndim == 1
         assert straight.shape[0] == self.t.shape[1]
         assert np.all(straight >= 0) and np.all(straight <= 1)
-        np.testing.assert_almost_equal(straight[0], 1.)
+        np.testing.assert_almost_equal(straight[0], 1.0)
 
     @pytest.fixture(autouse=True)
     def run_around_tests(self):
@@ -44,19 +51,19 @@ class TestWithStraightTrajectory():
         assert np.all(t == self.t)
 
 
-
-class TestExtraDimensions():
+class TestExtraDimensions:
     def setup_class(self):
         self.u = np.random.rand(10, 12, 2)
         self.u_2 = self.u.reshape((10, 3, 4, 2))
 
-    @pytest.mark.parametrize("func", [straightness, distance_travelled,
-                                      norm, normalise])
+    @pytest.mark.parametrize(
+        "func", [straightness, distance_travelled, norm, normalise]
+    )
     def test_extra_dimensions(self, func):
         normal = func(self.u)
         reshaped = np.reshape(func(self.u_2), normal.shape)
         np.testing.assert_almost_equal(normal, reshaped)
-    
+
     @pytest.fixture(autouse=True)
     def run_around_tests(self):
         u = self.u.copy()
@@ -67,8 +74,7 @@ class TestExtraDimensions():
         assert np.all(u_2 == self.u_2)
 
 
-
-class TestAngleBetweenVectors():
+class TestAngleBetweenVectors:
     def setup_class(self):
         self.u = np.random.rand(10, 4, 2)
         self.v = np.random.rand(10, 4, 2)
@@ -84,7 +90,7 @@ class TestAngleBetweenVectors():
         np.testing.assert_almost_equal(signed, -signed_flipped)
 
 
-class TestRotate():
+class TestRotate:
     def setup_class(self):
         self.t = np.random.rand(10, 4, 2)
         self.t2 = np.random.rand(10, 4, 2)
@@ -97,14 +103,16 @@ class TestRotate():
             e_y_like_v = np.zeros_like(v)
             e_y_like_v[..., 1] = 1
             np.testing.assert_almost_equal(
-                v_rot, norm(v, keepdims=True)*e_y_like_v)
-        
+                v_rot, norm(v, keepdims=True) * e_y_like_v
+            )
+
     def test_own_t(self):
         t_rot = fixed_to_comoving(self.t, self.t)
         e_y_like_t = np.zeros_like(self.t)
         e_y_like_t[..., 1] = 1
         np.testing.assert_almost_equal(
-            t_rot, norm(self.t, keepdims=True)*e_y_like_t)
+            t_rot, norm(self.t, keepdims=True) * e_y_like_t
+        )
 
     def test_fixed_to_comoving_unnormalised(self):
         t_rot1 = fixed_to_comoving(self.t, self.v)
@@ -131,7 +139,7 @@ class TestRotate():
         angles1 = signed_angle_between_vectors(self.t, t_rot)
         angles2 = signed_angle_between_vectors(self.v, e_y)
         np.testing.assert_almost_equal(angles1, angles2)
-   
+
     def test_comoving_to_fixed(self):
         t_rot = fixed_to_comoving(self.t, self.v)
         t_back = comoving_to_fixed(t_rot, self.v)
@@ -145,6 +153,7 @@ class TestRotate():
         # Check there are no side effects
         assert np.all(v == self.v)
         assert np.all(t == self.t)
+
 
 class TestRotateWithNeighbours(TestRotate):
     def setup_class(self):

--- a/tests/interpolate_test.py
+++ b/tests/interpolate_test.py
@@ -1,12 +1,12 @@
-import pytest
 import numpy as np
+import pytest
 
+import trajectorytools as tt
 import trajectorytools.constants as cons
 from trajectorytools.interpolate import (
     find_enclosing_circle,
     find_enclosing_circle_simple,
 )
-import trajectorytools as tt
 
 
 class TestCircle:

--- a/tests/interpolate_test.py
+++ b/tests/interpolate_test.py
@@ -2,21 +2,30 @@ import pytest
 import numpy as np
 
 import trajectorytools.constants as cons
-from trajectorytools.interpolate import (find_enclosing_circle,
-                                         find_enclosing_circle_simple)
+from trajectorytools.interpolate import (
+    find_enclosing_circle,
+    find_enclosing_circle_simple,
+)
 import trajectorytools as tt
 
 
-class TestCircle():
+class TestCircle:
     def setup_class(self):
-        angles = np.random.rand(50, 10)*2*np.pi
+        angles = np.random.rand(50, 10) * 2 * np.pi
         self.center = np.random.randn(2)
         self.R = 1 + np.random.rand(1)
-        self.t = np.stack([self.R * np.cos(angles) + self.center[0],
-                           self.R * np.sin(angles) + self.center[1]], axis=-1)
+        self.t = np.stack(
+            [
+                self.R * np.cos(angles) + self.center[0],
+                self.R * np.sin(angles) + self.center[1],
+            ],
+            axis=-1,
+        )
 
-    @pytest.mark.parametrize("func_find_circle", [find_enclosing_circle,
-                                                  find_enclosing_circle_simple])
+    @pytest.mark.parametrize(
+        "func_find_circle",
+        [find_enclosing_circle, find_enclosing_circle_simple],
+    )
     def test_consistency(self, func_find_circle):
         center_x, center_y, radius = func_find_circle(self.t)
         # It is possible but highly improbable that this test fails by chance
@@ -24,13 +33,14 @@ class TestCircle():
         assert pytest.approx(center_y, 1e-2) == self.center[1]
         assert pytest.approx(radius, 1e-2) == self.R
 
-    @pytest.mark.parametrize("func_find_circle", [find_enclosing_circle,
-                                                  find_enclosing_circle_simple])
+    @pytest.mark.parametrize(
+        "func_find_circle",
+        [find_enclosing_circle, find_enclosing_circle_simple],
+    )
     def test_consistency_some_nans(self, func_find_circle, num_nans=2):
         t = self.t.copy()
         for i in range(num_nans):
-            t[np.random.randint(0, 50),
-              np.random.randint(0, 10), :] = np.nan
+            t[np.random.randint(0, 50), np.random.randint(0, 10), :] = np.nan
         center_x, center_y, radius = func_find_circle(t)
         # It is possible but highly improbable that this test fails by chance
         assert pytest.approx(center_x, 1e-2) == self.center[0]

--- a/tests/socialcontext_test.py
+++ b/tests/socialcontext_test.py
@@ -5,12 +5,14 @@ import trajectorytools.constants as cons
 from trajectorytools.socialcontext import in_convex_hull, in_alpha_border
 import trajectorytools as tt
 
+
 def test_convex_hull_vs_alpha_border():
     t = np.load(cons.test_raw_trajectories_path, allow_pickle=True)
     tt.interpolate_nans(t)
 
-    convex_hull = in_convex_hull(t) 
+    convex_hull = in_convex_hull(t)
     alpha_border = in_alpha_border(t)
-    in_alpha_border_not_in_convex_hull = np.logical_and(np.logical_not(alpha_border), 
-                                                        convex_hull)
+    in_alpha_border_not_in_convex_hull = np.logical_and(
+        np.logical_not(alpha_border), convex_hull
+    )
     assert not np.any(in_alpha_border_not_in_convex_hull)

--- a/tests/socialcontext_test.py
+++ b/tests/socialcontext_test.py
@@ -1,9 +1,9 @@
-import pytest
 import numpy as np
+import pytest
 
-import trajectorytools.constants as cons
-from trajectorytools.socialcontext import in_convex_hull, in_alpha_border
 import trajectorytools as tt
+import trajectorytools.constants as cons
+from trajectorytools.socialcontext import in_alpha_border, in_convex_hull
 
 
 def test_convex_hull_vs_alpha_border():

--- a/tests/test_trajectories.py
+++ b/tests/test_trajectories.py
@@ -1,4 +1,3 @@
-import copy
 import tempfile
 import unittest
 

--- a/tests/test_trajectories.py
+++ b/tests/test_trajectories.py
@@ -21,7 +21,7 @@ class TrajectoriesTestCase(unittest.TestCase):
         assert len(self.t) == self.t._s.shape[0]
 
     def test_center_of_mass(self):
-        assert(self.t.params is self.t.center_of_mass.params)  # Same object
+        assert self.t.params is self.t.center_of_mass.params  # Same object
         nptest.assert_allclose(self.t.s.mean(axis=1), self.t.center_of_mass.s)
         nptest.assert_allclose(self.t.v.mean(axis=1), self.t.center_of_mass.v)
         nptest.assert_allclose(self.t.a.mean(axis=1), self.t.center_of_mass.a)
@@ -29,8 +29,9 @@ class TrajectoriesTestCase(unittest.TestCase):
     def test_slice(self):
         new_t = self.t[50:100]
         assert isinstance(new_t, Trajectories)
-        self.assertEqual(new_t.number_of_individuals,
-                         self.t.number_of_individuals)
+        self.assertEqual(
+            new_t.number_of_individuals, self.t.number_of_individuals
+        )
         nptest.assert_equal(new_t.s, self.t.s[50:100])
         nptest.assert_equal(new_t.v, self.t.v[50:100])
         nptest.assert_equal(new_t.a, self.t.a[50:100])
@@ -38,23 +39,21 @@ class TrajectoriesTestCase(unittest.TestCase):
     def test_restrict_individuals(self):
         n_individuals = 3
         individuals = np.random.permutation(
-            np.arange(self.t.number_of_individuals))[:n_individuals]
+            np.arange(self.t.number_of_individuals)
+        )[:n_individuals]
         new_t = self.t.restrict_individuals(individuals)
         nptest.assert_equal(new_t.s, self.t.s[:, individuals])
         nptest.assert_equal(new_t.v, self.t.v[:, individuals])
         nptest.assert_equal(new_t.a, self.t.a[:, individuals])
 
     def test_to_px(self):
-        nptest.assert_allclose(self.t.point_to_px(self.t.s),
-                               self.t._s)
-        nptest.assert_allclose(self.t.vector_to_px(self.t.v),
-                               self.t._v)
-        nptest.assert_allclose(self.t.vector_to_px(self.t.a),
-                               self.t._a)
+        nptest.assert_allclose(self.t.point_to_px(self.t.s), self.t._s)
+        nptest.assert_allclose(self.t.vector_to_px(self.t.v), self.t._v)
+        nptest.assert_allclose(self.t.vector_to_px(self.t.a), self.t._a)
 
     def test_check_unit_change(self, new_length_unit=10, new_time_unit=5):
-        length_unit = self.t.params['length_unit']
-        time_unit = self.t.params['time_unit']
+        length_unit = self.t.params["length_unit"]
+        time_unit = self.t.params["time_unit"]
         factor_length = new_length_unit / length_unit
         factor_time = new_time_unit / time_unit
 
@@ -64,13 +63,13 @@ class TrajectoriesTestCase(unittest.TestCase):
         self.t.new_time_unit(new_time_unit)
         nptest.assert_allclose(self.t.s, s)
         nptest.assert_allclose(self.t.v, v * factor_time)
-        nptest.assert_allclose(self.t.a, a * factor_time**2)
+        nptest.assert_allclose(self.t.a, a * factor_time ** 2)
 
         # We check a length unit change
         self.t.new_length_unit(new_length_unit)
-        nptest.assert_allclose(self.t.s, s/factor_length)
-        nptest.assert_allclose(self.t.v, v/factor_length * factor_time)
-        nptest.assert_allclose(self.t.a, a/factor_length * factor_time**2)
+        nptest.assert_allclose(self.t.s, s / factor_length)
+        nptest.assert_allclose(self.t.v, v / factor_length * factor_time)
+        nptest.assert_allclose(self.t.a, a / factor_length * factor_time ** 2)
 
     def test_straightness(self):
         straight = self.t.straightness
@@ -80,31 +79,35 @@ class TrajectoriesTestCase(unittest.TestCase):
         assert straight.shape[0] == self.t.number_of_individuals
 
     def test_acceleration(self):
-        nptest.assert_allclose(self.t.acceleration,
-                               np.sqrt(self.t.normal_acceleration**2 +
-                                       self.t.tg_acceleration**2)
-                               )
+        nptest.assert_allclose(
+            self.t.acceleration,
+            np.sqrt(
+                self.t.normal_acceleration ** 2 + self.t.tg_acceleration ** 2
+            ),
+        )
+
 
 class TrajectoriesTestCaseUnitChange(TrajectoriesTestCase):
     def setUp(self):
         self.t = Trajectories.from_idtrackerai(cons.test_trajectories_path)
         self.t_unchanged = Trajectories.from_idtrackerai(
-            cons.test_trajectories_path)
+            cons.test_trajectories_path
+        )
         self.new_length_unit = 3
         self.t.new_length_unit(self.new_length_unit)
 
     def test_check_only_length_change(self):
-        length_unit = self.t_unchanged.params['length_unit']
+        length_unit = self.t_unchanged.params["length_unit"]
         factor_length = self.new_length_unit / length_unit
 
         s, v, a = self.t_unchanged.s, self.t_unchanged.v, self.t_unchanged.a
-        nptest.assert_allclose(self.t.s, s/factor_length)
-        nptest.assert_allclose(self.t.v, v/factor_length)
-        nptest.assert_allclose(self.t.a, a/factor_length)
+        nptest.assert_allclose(self.t.s, s / factor_length)
+        nptest.assert_allclose(self.t.v, v / factor_length)
+        nptest.assert_allclose(self.t.a, a / factor_length)
 
     def test_check_time_change_after_length_change(self):
-        length_unit = self.t_unchanged.params['length_unit']
-        time_unit = self.t_unchanged.params['time_unit']
+        length_unit = self.t_unchanged.params["length_unit"]
+        time_unit = self.t_unchanged.params["time_unit"]
         new_time_unit = 3
         factor_length = self.new_length_unit / length_unit
         factor_time = new_time_unit / time_unit
@@ -112,32 +115,37 @@ class TrajectoriesTestCaseUnitChange(TrajectoriesTestCase):
         self.t.new_time_unit(new_time_unit)
 
         s, v, a = self.t_unchanged.s, self.t_unchanged.v, self.t_unchanged.a
-        nptest.assert_allclose(self.t.s, s/factor_length)
-        nptest.assert_allclose(self.t.v, v/factor_length * factor_time)
-        nptest.assert_allclose(self.t.a, a/factor_length * factor_time**2)
+        nptest.assert_allclose(self.t.s, s / factor_length)
+        nptest.assert_allclose(self.t.v, v / factor_length * factor_time)
+        nptest.assert_allclose(self.t.a, a / factor_length * factor_time ** 2)
 
     def test_estimation_enclosing_circle(self):
         center, r = self.t.estimate_center_and_radius_from_locations()
         center_px, r_px = self.t.estimate_center_and_radius_from_locations(
-            in_px=True)
+            in_px=True
+        )
         nptest.assert_allclose(self.t.point_to_px(center), center_px)
         nptest.assert_allclose(self.t.point_from_px(center_px), center)
-        nptest.assert_allclose(r_px/r, self.t.params['length_unit'])
+        nptest.assert_allclose(r_px / r, self.t.params["length_unit"])
 
     def test_invariance_straightness(self):
-        nptest.assert_allclose(self.t.straightness,
-                               self.t_unchanged.straightness)
+        nptest.assert_allclose(
+            self.t.straightness, self.t_unchanged.straightness
+        )
 
     def test_scaling_distance_travelled(self):
-        nptest.assert_allclose(self.t.distance_travelled * self.new_length_unit,
-                               self.t_unchanged.distance_travelled)
+        nptest.assert_allclose(
+            self.t.distance_travelled * self.new_length_unit,
+            self.t_unchanged.distance_travelled,
+        )
 
 
 class TrajectoriesTestCaseSaveLoad(TrajectoriesTestCase):
     def setUp(self):
         t = Trajectories.from_idtrackerai(cons.test_trajectories_path)
         temporary_file = tempfile.mkstemp(
-            '.npy', 'trajectorytoolstest', '/tmp')[1]
+            ".npy", "trajectorytoolstest", "/tmp"
+        )[1]
         t.save(temporary_file)
         self.t = Trajectories.load(temporary_file)
         self.t1 = Trajectories.from_idtrackerai(cons.test_trajectories_path)
@@ -148,12 +156,12 @@ class TrajectoriesTestCaseSaveLoad(TrajectoriesTestCase):
         nptest.assert_equal(self.t1.a, self.t.a)
         for key in self.t.params:
             try:
-                assert(self.t.params[key] == self.t1.params[key])
+                assert self.t.params[key] == self.t1.params[key]
             except ValueError:
                 nptest.assert_equal(self.t.params[key], self.t1.params[key])
         for key in self.t1.params:
             try:
-                assert(self.t.params[key] == self.t1.params[key])
+                assert self.t.params[key] == self.t1.params[key]
             except ValueError:
                 nptest.assert_equal(self.t.params[key], self.t1.params[key])
 
@@ -161,9 +169,10 @@ class TrajectoriesTestCaseSaveLoad(TrajectoriesTestCase):
 class TrajectoriesTestCase2(TrajectoriesTestCase):
     def test_interindividual_distances(self):
         d1 = self.t.interindividual_distances
-        d2 = ttsocial.adjacency_matrix(self.t.s, mode='distance')
-        d3 = ttsocial.adjacency_matrix(self.t.s, mode='distance',
-                                       use_pdist_if_all_nb=False)
+        d2 = ttsocial.adjacency_matrix(self.t.s, mode="distance")
+        d3 = ttsocial.adjacency_matrix(
+            self.t.s, mode="distance", use_pdist_if_all_nb=False
+        )
         nptest.assert_equal(d1, d2)
         nptest.assert_equal(d2, d3)
 
@@ -209,7 +218,7 @@ class TrajectoriesTestCase4(TrajectoriesTestCase):
     def test_split_consistency2(self):
         d1 = self.t[30:].distance_travelled
         d = self.t.distance_travelled[30:]
-        nptest.assert_allclose(d1[1], d[1]-d[0])
+        nptest.assert_allclose(d1[1], d[1] - d[0])
 
     def test_split_consistency3(self):
         f = self.t[:31].distance_travelled
@@ -218,21 +227,24 @@ class TrajectoriesTestCase4(TrajectoriesTestCase):
         nptest.assert_allclose(all[30:], s + f[-1])
 
     def test_split_consistency(self):
-        from_first = self.t[:self.index_cut].distance_travelled
-        from_second = self.t[(self.index_cut - 1):].distance_travelled
+        from_first = self.t[: self.index_cut].distance_travelled
+        from_second = self.t[(self.index_cut - 1) :].distance_travelled
         from_original = self.t.distance_travelled
         # Distance travelled in the first part should be the same
-        nptest.assert_allclose(from_original[:self.index_cut], from_first)
+        nptest.assert_allclose(from_original[: self.index_cut], from_first)
         # Distance travelled in second is offset by total travelled in first
         total_travelled_in_first = from_first[-1]
-        nptest.assert_allclose(from_original[(self.index_cut - 1):],
-                               from_second + total_travelled_in_first)
+        nptest.assert_allclose(
+            from_original[(self.index_cut - 1) :],
+            from_second + total_travelled_in_first,
+        )
 
 
 class TrajectoriesWithPointsTestCase(TrajectoriesTestCase):
     def setUp(self):
         self.t = TrajectoriesWithPoints.from_idtrackerai(
-            cons.test_trajectories_with_points_path, center=True)
+            cons.test_trajectories_with_points_path, center=True
+        )
 
     def test_correct_class(self):
         assert isinstance(self.t, TrajectoriesWithPoints)
@@ -241,13 +253,16 @@ class TrajectoriesWithPointsTestCase(TrajectoriesTestCase):
 class TrajectoriesWithPointsTestCaseSaveLoad(TrajectoriesWithPointsTestCase):
     def setUp(self):
         t = TrajectoriesWithPoints.from_idtrackerai(
-            cons.test_trajectories_with_points_path)
+            cons.test_trajectories_with_points_path
+        )
         temporary_file = tempfile.mkstemp(
-            '.npy', 'trajectorytoolstest', '/tmp')[1]
+            ".npy", "trajectorytoolstest", "/tmp"
+        )[1]
         t.save(temporary_file)
         self.t = TrajectoriesWithPoints.load(temporary_file)
         self.t1 = TrajectoriesWithPoints.from_idtrackerai(
-            cons.test_trajectories_with_points_path)
+            cons.test_trajectories_with_points_path
+        )
 
     def test_save_and_load_equal(self):
         nptest.assert_equal(self.t1.s, self.t.s)
@@ -255,12 +270,12 @@ class TrajectoriesWithPointsTestCaseSaveLoad(TrajectoriesWithPointsTestCase):
         nptest.assert_equal(self.t1.a, self.t.a)
         for key in self.t.points:
             try:
-                assert(self.t.points[key] == self.t1.points[key])
+                assert self.t.points[key] == self.t1.points[key]
             except ValueError:
                 nptest.assert_equal(self.t.points[key], self.t1.points[key])
         for key in self.t1.points:
             try:
-                assert(self.t.points[key] == self.t1.points[key])
+                assert self.t.points[key] == self.t1.points[key]
             except ValueError:
                 nptest.assert_equal(self.t.points[key], self.t1.points[key])
 
@@ -268,40 +283,50 @@ class TrajectoriesWithPointsTestCaseSaveLoad(TrajectoriesWithPointsTestCase):
 class TrajectoriesWithPointsTestCaseCenter(TrajectoriesWithPointsTestCase):
     def setUp(self):
         self.t = TrajectoriesWithPoints.from_idtrackerai(
-            cons.test_trajectories_with_points_path, center=False)
+            cons.test_trajectories_with_points_path, center=False
+        )
         self.t_center = TrajectoriesWithPoints.from_idtrackerai(
-            cons.test_trajectories_with_points_path, center=True)
+            cons.test_trajectories_with_points_path, center=True
+        )
 
     def test_recenter(self):
         self.t_center.origin_to(np.zeros(2))
         nptest.assert_allclose(self.t_center._s, self.t._s)
         for key in self.t_center.points:
-            nptest.assert_allclose(self.t_center.points[key],
-                                   self.t.points[key])
+            nptest.assert_allclose(
+                self.t_center.points[key], self.t.points[key]
+            )
 
 
-class TrajectoriesWithPointsTestCaseChangeLengthUnit(TrajectoriesWithPointsTestCase):
+class TrajectoriesWithPointsTestCaseChangeLengthUnit(
+    TrajectoriesWithPointsTestCase
+):
     def setUp(self):
         self.t = TrajectoriesWithPoints.from_idtrackerai(
-            cons.test_trajectories_with_points_path, center=True)
+            cons.test_trajectories_with_points_path, center=True
+        )
         self.t2 = TrajectoriesWithPoints.from_idtrackerai(
-            cons.test_trajectories_with_points_path, center=True)
+            cons.test_trajectories_with_points_path, center=True
+        )
         self.new_length_unit = 10
         # Scaling trajectory self.t by 10
         self.factor = self.t.new_length_unit(self.new_length_unit)
 
     def test_check_unit_length_change_in_points(self):
-        length_unit = self.t2.params['length_unit']
+        length_unit = self.t2.params["length_unit"]
         factor_length = length_unit / self.new_length_unit
         nptest.assert_allclose(self.factor, factor_length)
 
         for point in self.t.points:
             nptest.assert_allclose(
-                self.t.points[point], self.t2.points[point] * factor_length)
+                self.t.points[point], self.t2.points[point] * factor_length
+            )
 
     def test_check_unit_length_change_in_points_twice(self):
-        length_unit = self.t2.params['length_unit']
-        factor_length = length_unit / self.new_length_unit  # Factor of first change
+        length_unit = self.t2.params["length_unit"]
+        factor_length = (
+            length_unit / self.new_length_unit
+        )  # Factor of first change
 
         # Factor 1 in the second change
         factor2 = self.t.new_length_unit(self.new_length_unit)
@@ -309,18 +334,19 @@ class TrajectoriesWithPointsTestCaseChangeLengthUnit(TrajectoriesWithPointsTestC
 
         for point in self.t.points:
             nptest.assert_allclose(
-                self.t.points[point], self.t2.points[point] * factor_length)
+                self.t.points[point], self.t2.points[point] * factor_length
+            )
 
     def test_check_unit_length_change_in_points_and_back(self):
         factor2 = self.t.new_length_unit(1)
-        nptest.assert_allclose(factor2, 1/self.factor)
+        nptest.assert_allclose(factor2, 1 / self.factor)
 
         for point in self.t.points:
             nptest.assert_allclose(self.t.points[point], self.t2.points[point])
 
     def test_check_unit_length_change_in_points_and_back_twice(self):
         factor2 = self.t.new_length_unit(1)
-        nptest.assert_allclose(factor2, 1/self.factor)
+        nptest.assert_allclose(factor2, 1 / self.factor)
         factor3 = self.t.new_length_unit(1)
         nptest.assert_allclose(factor3, 1)
 
@@ -328,15 +354,19 @@ class TrajectoriesWithPointsTestCaseChangeLengthUnit(TrajectoriesWithPointsTestC
             nptest.assert_allclose(self.t.points[point], self.t2.points[point])
 
 
-class TrajectoriesWithPointsSlicedTestCaseChangeLengthUnit(TrajectoriesWithPointsTestCase):
+class TrajectoriesWithPointsSlicedTestCaseChangeLengthUnit(
+    TrajectoriesWithPointsTestCase
+):
     def setUp(self):
         self.t = TrajectoriesWithPoints.from_idtrackerai(
-            cons.test_trajectories_with_points_path, center=True)
+            cons.test_trajectories_with_points_path, center=True
+        )
         self.t2 = TrajectoriesWithPoints.from_idtrackerai(
-            cons.test_trajectories_with_points_path, center=True)
+            cons.test_trajectories_with_points_path, center=True
+        )
 
     def test_check_unit_length_change_in_points(self, new_length_unit=10):
-        length_unit = self.t.params['length_unit']
+        length_unit = self.t.params["length_unit"]
 
         factor_length = length_unit / new_length_unit
 
@@ -347,10 +377,13 @@ class TrajectoriesWithPointsSlicedTestCaseChangeLengthUnit(TrajectoriesWithPoint
 
         for point in self.t.points:
             nptest.assert_allclose(
-                sliced_t.points[point], self.t2.points[point] * factor_length)
+                sliced_t.points[point], self.t2.points[point] * factor_length
+            )
 
-    def test_check_unit_length_change_in_points_twice(self, new_length_unit=10):
-        length_unit = self.t.params['length_unit']
+    def test_check_unit_length_change_in_points_twice(
+        self, new_length_unit=10
+    ):
+        length_unit = self.t.params["length_unit"]
 
         factor_length = length_unit / new_length_unit
 
@@ -363,10 +396,13 @@ class TrajectoriesWithPointsSlicedTestCaseChangeLengthUnit(TrajectoriesWithPoint
 
         for point in self.t.points:
             nptest.assert_allclose(
-                sliced_t.points[point], self.t2.points[point] * factor_length)
+                sliced_t.points[point], self.t2.points[point] * factor_length
+            )
 
-    def test_check_unit_length_change_in_points_and_back(self, new_length_unit=10):
-        length_unit = self.t.params['length_unit']
+    def test_check_unit_length_change_in_points_and_back(
+        self, new_length_unit=10
+    ):
+        length_unit = self.t.params["length_unit"]
 
         factor_length = length_unit / new_length_unit
 
@@ -375,14 +411,17 @@ class TrajectoriesWithPointsSlicedTestCaseChangeLengthUnit(TrajectoriesWithPoint
 
         sliced_t = self.t[50:100]
         factor = sliced_t.new_length_unit(1)
-        nptest.assert_allclose(factor, 1/factor_length)
+        nptest.assert_allclose(factor, 1 / factor_length)
 
         for point in self.t.points:
             nptest.assert_allclose(
-                sliced_t.points[point], self.t2.points[point])
+                sliced_t.points[point], self.t2.points[point]
+            )
 
-    def test_check_unit_length_change_in_points_and_back_twice(self, new_length_unit=10):
-        length_unit = self.t.params['length_unit']
+    def test_check_unit_length_change_in_points_and_back_twice(
+        self, new_length_unit=10
+    ):
+        length_unit = self.t.params["length_unit"]
 
         factor_length = length_unit / new_length_unit
 
@@ -391,75 +430,85 @@ class TrajectoriesWithPointsSlicedTestCaseChangeLengthUnit(TrajectoriesWithPoint
 
         sliced_t1 = self.t[50:100]
         factor = sliced_t1.new_length_unit(1)
-        nptest.assert_allclose(factor, 1/factor_length)
+        nptest.assert_allclose(factor, 1 / factor_length)
 
         sliced_t2 = self.t[150:200]
         factor = sliced_t2.new_length_unit(1)
-        nptest.assert_allclose(factor, 1/factor_length)
+        nptest.assert_allclose(factor, 1 / factor_length)
 
         for point in self.t.points:
             nptest.assert_allclose(
-                sliced_t1.points[point], self.t2.points[point])
+                sliced_t1.points[point], self.t2.points[point]
+            )
             nptest.assert_allclose(
-                sliced_t2.points[point], self.t2.points[point])
+                sliced_t2.points[point], self.t2.points[point]
+            )
 
 
 class RawTrajectoriesTestCase(TrajectoriesTestCase):
     def setUp(self):
         t = np.load(cons.test_raw_trajectories_path, allow_pickle=True)
-        self.t = Trajectories.from_positions(t, smooth_params={'sigma': 1})
+        self.t = Trajectories.from_positions(t, smooth_params={"sigma": 1})
 
 
 class ArenaRadiusCenterFromBorder(TrajectoriesTestCase):
     def setUp(self):
         self.t = Trajectories.from_idtrackerai(
-            cons.test_trajectories_path_border)
+            cons.test_trajectories_path_border
+        )
 
     def test_arena_radius_and_center_from_border(self):
         # The width and height of the frame are 1160 and 938 pixels
         # respectively. In the trajectories dictionary there
         # is a key named 'setup_points'
         nptest.assert_allclose(
-            self.t.params['_center'], (580, 469), rtol=.1, atol=1.)
+            self.t.params["_center"], (580, 469), rtol=0.1, atol=1.0
+        )
         nptest.assert_allclose(
-            self.t.params['radius_px'], 400, rtol=.1, atol=1.)
+            self.t.params["radius_px"], 400, rtol=0.1, atol=1.0
+        )
 
 
 class CenterTrajectoriesTestCase(TrajectoriesTestCase):
     def setUp(self):
         self.t_nocenter = Trajectories.from_idtrackerai(
-            cons.test_trajectories_path)
+            cons.test_trajectories_path
+        )
         self.t = Trajectories.from_idtrackerai(
-            cons.test_trajectories_path, center=True)
+            cons.test_trajectories_path, center=True
+        )
 
     def test_recenter(self):
         self.t.origin_to(np.zeros(2))
         nptest.assert_allclose(self.t_nocenter._s, self.t._s)
 
     def test_recenter2(self):
-        self.t_nocenter.origin_to(self.t.params['_center'])
+        self.t_nocenter.origin_to(self.t.params["_center"])
         nptest.assert_allclose(self.t_nocenter._s, self.t._s)
 
 
 class SmoothTrajectoriesTestCase(TrajectoriesTestCase):
     def setUp(self):
-        self.t = Trajectories.from_idtrackerai(cons.test_trajectories_path,
-                                               smooth_params={'sigma': 1})
+        self.t = Trajectories.from_idtrackerai(
+            cons.test_trajectories_path, smooth_params={"sigma": 1}
+        )
 
 
 def assert_global_allclose(a, b, rel_error):
     # For things that are around 0
-    abs_error = rel_error*min(a.std(), b.std())
+    abs_error = rel_error * min(a.std(), b.std())
     nptest.assert_allclose(a, b, rtol=0, atol=abs_error)
 
 
 class CenterScaleTrajectoriesTestCase(TrajectoriesTestCase):
     def setUp(self):
         self.t_nocenter = Trajectories.from_idtrackerai(
-            cons.test_trajectories_path).normalise_by('radius')
+            cons.test_trajectories_path
+        ).normalise_by("radius")
         self.t = Trajectories.from_idtrackerai(
-            cons.test_trajectories_path, center=True).normalise_by('radius')
-        self.rel_error = [1e-14]*2
+            cons.test_trajectories_path, center=True
+        ).normalise_by("radius")
+        self.rel_error = [1e-14] * 2
 
     def test_recenter(self):
         self.t.origin_to(np.zeros(2))
@@ -467,18 +516,20 @@ class CenterScaleTrajectoriesTestCase(TrajectoriesTestCase):
         nptest.assert_allclose(self.t_nocenter._v, self.t._v)
 
     def test_recenter2(self):
-        self.t_nocenter.origin_to(self.t.params['_center'])
+        self.t_nocenter.origin_to(self.t.params["_center"])
         nptest.assert_allclose(self.t_nocenter._s, self.t._s)
         nptest.assert_allclose(self.t_nocenter._v, self.t._v)
 
 
 class DoubleTrajectoriesTestCase(TrajectoriesTestCase):
     def setUp(self):
-        self.t = Trajectories.from_idtrackerai(cons.test_trajectories_path,
-                                               smooth_params={'sigma': 2})
-        self.t2 = Trajectories.from_idtrackerai(cons.test_trajectories_path,
-                                                smooth_params={'sigma': 2})
-        self.rel_error = [1e-14]*3
+        self.t = Trajectories.from_idtrackerai(
+            cons.test_trajectories_path, smooth_params={"sigma": 2}
+        )
+        self.t2 = Trajectories.from_idtrackerai(
+            cons.test_trajectories_path, smooth_params={"sigma": 2}
+        )
+        self.rel_error = [1e-14] * 3
 
     def test_close_to_original(self):
         assert_global_allclose(self.t.s, self.t2.s, self.rel_error[0])
@@ -497,7 +548,7 @@ class UpDownResample(DoubleTrajectoriesTestCase):
         super().setUp()
         factor = 2.0
         frame_rate = self.t.params["frame_rate"]
-        self.t.resample(frame_rate*factor)
+        self.t.resample(frame_rate * factor)
         self.t.resample(frame_rate)
         self.rel_error = [2e-3, 5e-2, 0.3]
 
@@ -507,7 +558,7 @@ class DownUpResample(DoubleTrajectoriesTestCase):
         super().setUp()
         factor = 0.5
         frame_rate = self.t.params["frame_rate"]
-        self.t.resample(frame_rate*factor)
+        self.t.resample(frame_rate * factor)
         self.t.resample(frame_rate)
         # Poor in acceleration (changes fast)
         self.rel_error = [5e-2, 0.5, 1.0]
@@ -515,51 +566,55 @@ class DownUpResample(DoubleTrajectoriesTestCase):
 
 class ScaleRadiusTrajectoriesTestCase(TrajectoriesTestCase):
     def setUp(self):
-        self.t = Trajectories.from_idtracker(cons.test_trajectories_path, center=True
-                                             ).normalise_by('radius')
+        self.t = Trajectories.from_idtracker(
+            cons.test_trajectories_path, center=True
+        ).normalise_by("radius")
         self.t_normal = Trajectories.from_idtracker(
-            cons.test_trajectories_path)
+            cons.test_trajectories_path
+        )
 
     def test_scale(self):
         corrected_s = self.t_normal.s
-        corrected_s[..., 0] -= self.t_normal.params['_center'][0]
-        corrected_s[..., 1] -= self.t_normal.params['_center'][1]
-        corrected_s /= self.t.params['radius_px']
-        corrected_v = self.t_normal.v / self.t.params['radius_px']
-        corrected_a = self.t_normal.a / self.t.params['radius_px']
-        #nptest.assert_allclose(self.t.s, corrected_s)
+        corrected_s[..., 0] -= self.t_normal.params["_center"][0]
+        corrected_s[..., 1] -= self.t_normal.params["_center"][1]
+        corrected_s /= self.t.params["radius_px"]
+        corrected_v = self.t_normal.v / self.t.params["radius_px"]
+        corrected_a = self.t_normal.a / self.t.params["radius_px"]
+        # nptest.assert_allclose(self.t.s, corrected_s)
         nptest.assert_allclose(self.t.v, corrected_v)
         nptest.assert_allclose(self.t.a, corrected_a, atol=1e-15)
 
     def test_transform_center(self):
-        center_px = self.t_normal.params['_center']
+        center_px = self.t_normal.params["_center"]
         center_transformed = self.t.point_from_px(center_px)
-        nptest.assert_allclose(center_transformed,
-                               np.zeros_like(center_transformed))
+        nptest.assert_allclose(
+            center_transformed, np.zeros_like(center_transformed)
+        )
 
     def test_transform_back_center(self):
         center_transformed = np.zeros(2)
         center_px = self.t.point_to_px(center_transformed)
-        nptest.assert_allclose(center_px,
-                               self.t_normal.params['_center'])
+        nptest.assert_allclose(center_px, self.t_normal.params["_center"])
 
 
 class TrajectoriesRadiusTestCase(TrajectoriesTestCase):
     def setUp(self):
-        self.t_normal = Trajectories.from_idtracker(cons.test_trajectories_path,
-                                                    smooth_params={'sigma': 1})
-        self.t = Trajectories.from_idtracker(cons.test_trajectories_path,
-                                             smooth_params={'sigma': 1}
-                                             ).normalise_by('radius')
+        self.t_normal = Trajectories.from_idtracker(
+            cons.test_trajectories_path, smooth_params={"sigma": 1}
+        )
+        self.t = Trajectories.from_idtracker(
+            cons.test_trajectories_path, smooth_params={"sigma": 1}
+        ).normalise_by("radius")
 
     def test_scaling(self):
-        self.assertEqual(self.t.params['radius'], 1.0)
-        nptest.assert_allclose(self.t.v,
-                               self.t_normal.v / self.t.params['radius_px'])
-        nptest.assert_allclose(self.t.a,
-                               self.t_normal.a / self.t.params['radius_px'],
-                               atol=1e-15)
+        self.assertEqual(self.t.params["radius"], 1.0)
+        nptest.assert_allclose(
+            self.t.v, self.t_normal.v / self.t.params["radius_px"]
+        )
+        nptest.assert_allclose(
+            self.t.a, self.t_normal.a / self.t.params["radius_px"], atol=1e-15
+        )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/trajectorytools/__init__.py
+++ b/trajectorytools/__init__.py
@@ -1,7 +1,13 @@
 from .geometry import *
 from .interpolate import *
-from .trajectories import Trajectories, FishTrajectories, TrajectoriesWithPoints
-#from . import animation
+from .trajectories import (
+    Trajectories,
+    FishTrajectories,
+    TrajectoriesWithPoints,
+)
+
+# from . import animation
 from . import socialcontext
 from . import collective
-#from . import plot
+
+# from . import plot

--- a/trajectorytools/__init__.py
+++ b/trajectorytools/__init__.py
@@ -1,13 +1,11 @@
+# from . import animation
+from . import collective, socialcontext
 from .geometry import *
 from .interpolate import *
 from .trajectories import (
-    Trajectories,
     FishTrajectories,
+    Trajectories,
     TrajectoriesWithPoints,
 )
-
-# from . import animation
-from . import socialcontext
-from . import collective
 
 # from . import plot

--- a/trajectorytools/animation/animation.py
+++ b/trajectorytools/animation/animation.py
@@ -7,33 +7,46 @@ import numpy as np
 from . import plotter
 from .scatter import Scatter
 
+
 class AnimatedScatter(object):
     """An animated scatter plot using matplotlib.animations.FuncAnimation."""
-    def __init__(self, datasets=[], plotters = []):
+
+    def __init__(self, datasets=[], plotters=[]):
         self.datasets = datasets
         self.plotters = plotters
 
-    def prepare(self, interval = 20, limits = [-1, 1, -1, 1],
-                axis_off = True, fig_ax = None):
+    def prepare(
+        self, interval=20, limits=[-1, 1, -1, 1], axis_off=True, fig_ax=None
+    ):
         frames = self.datasets[0].shape[0] - 1
-        self.scatters = [Scatter(self.datasets[i], plotter = self.plotters[i])
-                         for i in range(len(self.datasets))]
+        self.scatters = [
+            Scatter(self.datasets[i], plotter=self.plotters[i])
+            for i in range(len(self.datasets))
+        ]
         # Setup the figure and axes...
         if fig_ax is None:
             self.fig, self.ax = plt.subplots()
         else:
             self.fig, self.ax = fig_ax
 
-        self.fig.subplots_adjust(left=0, bottom=0, right=1, top=1,
-                                 wspace=None, hspace=None)
-        if axis_off: self.ax.axis('off')
+        self.fig.subplots_adjust(
+            left=0, bottom=0, right=1, top=1, wspace=None, hspace=None
+        )
+        if axis_off:
+            self.ax.axis("off")
         self.ax.axis(limits)
-        self.ax.set_aspect('equal')
+        self.ax.set_aspect("equal")
         # Then setup FuncAnimation.
-        self.ani = animation.FuncAnimation(self.fig, self.update,
-                                           interval=interval, frames = frames,
-                                           init_func=self.setup_plot, blit=True,
-                                           repeat = False)
+        self.ani = animation.FuncAnimation(
+            self.fig,
+            self.update,
+            interval=interval,
+            frames=frames,
+            init_func=self.setup_plot,
+            blit=True,
+            repeat=False,
+        )
+
     def setup_plot(self):
         """Initial drawing of the scatter plot."""
         scat_tuple = ()
@@ -51,39 +64,44 @@ class AnimatedScatter(object):
     def show(self):
         plt.show()
 
-    def save(self, video_file_name, fps = 10):
-        mywriter = animation.FFMpegWriter(codec="h264", fps = fps)
-        self.ani.save(video_file_name,writer=mywriter)
+    def save(self, video_file_name, fps=10):
+        mywriter = animation.FFMpegWriter(codec="h264", fps=fps)
+        self.ani.save(video_file_name, writer=mywriter)
 
     def __add__(self, other):
-        return AnimatedScatter(self.datasets + other.datasets,
-                               self.plotters + other.plotters)
+        return AnimatedScatter(
+            self.datasets + other.datasets, self.plotters + other.plotters
+        )
+
 
 def scatter(positions, **kwargs):
     plotters = [plotter.simple(**kwargs)]
-    return AnimatedScatter([positions], plotters = plotters)
+    return AnimatedScatter([positions], plotters=plotters)
+
 
 def scatter_circle(positions, **kwargs):
     plotters = [plotter.circle(**kwargs)]
-    return AnimatedScatter([positions], plotters = plotters)
+    return AnimatedScatter([positions], plotters=plotters)
+
 
 def scatter_labels(positions, **kwargs):
     plotters = [plotter.labels(**kwargs)]
-    return AnimatedScatter([positions], plotters = plotters)
+    return AnimatedScatter([positions], plotters=plotters)
+
 
 def scatter_ellipses(positions, velocities, **kwargs):
-    data = np.concatenate((positions, velocities), axis = -1)
+    data = np.concatenate((positions, velocities), axis=-1)
     plotters = [plotter.ellipse(**kwargs)]
-    return AnimatedScatter([data], plotters = plotters)
+    return AnimatedScatter([data], plotters=plotters)
+
 
 def scatter_ellipses_color(positions, velocities, color, **kwargs):
-    data = np.concatenate((positions, velocities, color), axis = -1)
+    data = np.concatenate((positions, velocities, color), axis=-1)
     plotters = [plotter.ellipse(**kwargs)]
-    return AnimatedScatter([data], plotters = plotters)
+    return AnimatedScatter([data], plotters=plotters)
+
 
 def scatter_vectors(positions, velocities, **kwargs):
-    data = np.concatenate((positions, velocities), axis = -1)
+    data = np.concatenate((positions, velocities), axis=-1)
     plotters = [plotter.vectors(**kwargs)]
-    return AnimatedScatter([data], plotters = plotters)
-
-
+    return AnimatedScatter([data], plotters=plotters)

--- a/trajectorytools/animation/animation.py
+++ b/trajectorytools/animation/animation.py
@@ -1,7 +1,7 @@
-import matplotlib.animation as animation
-import matplotlib.pyplot as plt
-import matplotlib.cm as cm
 import matplotlib as mpl
+import matplotlib.animation as animation
+import matplotlib.cm as cm
+import matplotlib.pyplot as plt
 import numpy as np
 
 from . import plotter

--- a/trajectorytools/animation/plotter.py
+++ b/trajectorytools/animation/plotter.py
@@ -1,6 +1,7 @@
 from collections import namedtuple
-import numpy as np
+
 import matplotlib as mpl
+import numpy as np
 
 Plotter = namedtuple("Plotter", "first update")
 
@@ -141,7 +142,7 @@ def labels(color="k", fontsize=15, labels=None, colors=None):
                     patch.set_color(color)
 
         if len(labels.shape) == 2:
-            label_list = labels[0].tolist()
+            labels[0].tolist()
 
         return lines
 

--- a/trajectorytools/animation/plotter.py
+++ b/trajectorytools/animation/plotter.py
@@ -36,23 +36,6 @@ def ellipse(color="c", size=[0.04, 0.02]):
     return Plotter(first=plot_function, update=update_function)
 
 
-# def identities():
-#    ##Changing this https://matplotlib.org/users/text_intro.html
-#    def plot_function(xy, ax):
-#        for
-#        patches = tuple(plt.text(x[0],x[1],str size[0],size[1],np.degrees(np.arctan2(x[3],x[2])), color = color, animated = True) for x in xy)
-#        for patch in patches:
-#            ax.add_patch(patch)
-#        return patches
-#    def update_function(xy, ax, patches):
-#        for i, patch in enumerate(patches):
-#            patch.center = xy[i,:2]
-#            patch.angle = np.degrees(np.arctan2(xy[i,3],xy[i,2]))
-#            patch.stale = True
-#        return patches
-#    return Plotter(first=plot_function, update=update_function)
-
-
 def simple(marker="o", color=[1, 0, 0]):
     def plot_function(xy, ax):
         return (

--- a/trajectorytools/animation/plotter.py
+++ b/trajectorytools/animation/plotter.py
@@ -2,26 +2,40 @@ from collections import namedtuple
 import numpy as np
 import matplotlib as mpl
 
-Plotter = namedtuple('Plotter', 'first update')
+Plotter = namedtuple("Plotter", "first update")
 
-def ellipse(color = 'c', size =[.04, .02]):
+
+def ellipse(color="c", size=[0.04, 0.02]):
     def plot_function(xy, ax):
-        patches = tuple(mpl.patches.Ellipse(x[:2],size[0],size[1],np.degrees(np.arctan2(x[3],x[2])), color = color, animated = True) for x in xy)
+        patches = tuple(
+            mpl.patches.Ellipse(
+                x[:2],
+                size[0],
+                size[1],
+                np.degrees(np.arctan2(x[3], x[2])),
+                color=color,
+                animated=True,
+            )
+            for x in xy
+        )
         for patch in patches:
             ax.add_patch(patch)
         return patches
+
     def update_function(xy, ax, patches, frame=None):
         for i, patch in enumerate(patches):
-            patch.center = xy[i,:2]
-            patch.angle = np.degrees(np.arctan2(xy[i,3],xy[i,2]))
-            if len(xy[i,:]) > 4: #If there is color information, use it
-                patch.set_facecolor(xy[i,4:])
-                patch.set_edgecolor(xy[i,4:])
+            patch.center = xy[i, :2]
+            patch.angle = np.degrees(np.arctan2(xy[i, 3], xy[i, 2]))
+            if len(xy[i, :]) > 4:  # If there is color information, use it
+                patch.set_facecolor(xy[i, 4:])
+                patch.set_edgecolor(xy[i, 4:])
             patch.stale = True
         return patches
+
     return Plotter(first=plot_function, update=update_function)
 
-#def identities():
+
+# def identities():
 #    ##Changing this https://matplotlib.org/users/text_intro.html
 #    def plot_function(xy, ax):
 #        for
@@ -37,38 +51,68 @@ def ellipse(color = 'c', size =[.04, .02]):
 #        return patches
 #    return Plotter(first=plot_function, update=update_function)
 
-def simple(marker = 'o', color = [1,0,0]):
+
+def simple(marker="o", color=[1, 0, 0]):
     def plot_function(xy, ax):
-        return ax.scatter(xy[:,0], xy[:,1], facecolor = 'none', edgecolors=color, marker = marker, animated=True),
+        return (
+            ax.scatter(
+                xy[:, 0],
+                xy[:, 1],
+                facecolor="none",
+                edgecolors=color,
+                marker=marker,
+                animated=True,
+            ),
+        )
+
     def update_function(xy, ax, scat, frame=None):
-        scat[0].set_offsets(xy[:,:2])
+        scat[0].set_offsets(xy[:, :2])
         return scat
+
     return Plotter(first=plot_function, update=update_function)
 
-def vectors(color = 'b', k = 1):
+
+def vectors(color="b", k=1):
     def plot_function(xy, ax):
-        lines = tuple(ax.plot([xy[i,0], xy[i,0] + xy[i,2]*k], [xy[i,1], xy[i,1] + xy[i,3]*k], color, animated = True)[0] for i in range(xy.shape[0]))
+        lines = tuple(
+            ax.plot(
+                [xy[i, 0], xy[i, 0] + xy[i, 2] * k],
+                [xy[i, 1], xy[i, 1] + xy[i, 3] * k],
+                color,
+                animated=True,
+            )[0]
+            for i in range(xy.shape[0])
+        )
         return lines
+
     def update_function(xy, ax, arrows, frame=None):
         for i in range(xy.shape[0]):
-            arrows[i].set_xdata([xy[i,0], xy[i,0] + xy[i,2]*k])
-            arrows[i].set_ydata([xy[i,1], xy[i,1] + xy[i,3]*k])
+            arrows[i].set_xdata([xy[i, 0], xy[i, 0] + xy[i, 2] * k])
+            arrows[i].set_ydata([xy[i, 1], xy[i, 1] + xy[i, 3] * k])
         return arrows
+
     return Plotter(first=plot_function, update=update_function)
 
-def circle(color = 'k', radius = 1):
+
+def circle(color="k", radius=1):
     def plot_function(xy, ax):
-        patches = tuple(mpl.patches.Circle((x[0], x[1]), radius, fill=False, animated = True) for x in xy)
+        patches = tuple(
+            mpl.patches.Circle((x[0], x[1]), radius, fill=False, animated=True)
+            for x in xy
+        )
         for patch in patches:
             ax.add_patch(patch)
         return patches
+
     def update_function(xy, ax, lines, frame=None):
         for i, patch in enumerate(lines):
-            patch.center = xy[i,0], xy[i,1]
+            patch.center = xy[i, 0], xy[i, 1]
         return lines
+
     return Plotter(first=plot_function, update=update_function)
 
-def labels(color = 'k', fontsize = 15, labels=None, colors=None):
+
+def labels(color="k", fontsize=15, labels=None, colors=None):
     def plot_function(xy, ax):
         if len(labels.shape) == 2:
             label_list = labels[0].tolist()
@@ -87,7 +131,7 @@ def labels(color = 'k', fontsize = 15, labels=None, colors=None):
     def update_function(xy, ax, lines, frame=None):
 
         for i, patch in enumerate(lines):
-            patch.set_position((xy[i,0], xy[i,1]))
+            patch.set_position((xy[i, 0], xy[i, 1]))
             patch.set_text(labels[frame][i])
 
         if colors is not None:
@@ -100,6 +144,5 @@ def labels(color = 'k', fontsize = 15, labels=None, colors=None):
             label_list = labels[0].tolist()
 
         return lines
+
     return Plotter(first=plot_function, update=update_function)
-
-

--- a/trajectorytools/animation/scatter.py
+++ b/trajectorytools/animation/scatter.py
@@ -1,9 +1,10 @@
 class Scatter(object):
-    def __init__(self, data, plotter = None):
+    def __init__(self, data, plotter=None):
         self.data = data
         self.stream = self.data_stream()
         self.plotter = plotter
         self.frame = None
+
     def first_plot(self, ax):
         self.frame = 0
         xy = next(self.stream)
@@ -14,12 +15,12 @@ class Scatter(object):
     def update_plot(self):
         self.frame += 1
         xy = next(self.stream)
-        self.scat = self.plotter.update(xy, self.ax,
-                                        self.scat, frame=self.frame)
+        self.scat = self.plotter.update(
+            xy, self.ax, self.scat, frame=self.frame
+        )
         return self.scat
 
     def data_stream(self):
-        while(True):
+        while True:
             for i in range(self.data.shape[0]):
                 yield self.data[i]
-

--- a/trajectorytools/collective.py
+++ b/trajectorytools/collective.py
@@ -1,6 +1,8 @@
-import numpy as np
-import trajectorytools as tt
 import warnings
+
+import numpy as np
+
+import trajectorytools as tt
 
 
 def average_across_individuals(s):

--- a/trajectorytools/collective.py
+++ b/trajectorytools/collective.py
@@ -2,6 +2,7 @@ import numpy as np
 import trajectorytools as tt
 import warnings
 
+
 def average_across_individuals(s):
     """ Averages along the penultimate dimension
     """

--- a/trajectorytools/constants.py
+++ b/trajectorytools/constants.py
@@ -3,9 +3,17 @@ import pathlib
 
 dir_of_executable = os.path.dirname(__file__)
 path_to_project_root = os.path.abspath(dir_of_executable)
-dir_of_data = path_to_project_root + '/data/'
+dir_of_data = path_to_project_root + "/data/"
 
-test_trajectories_path = pathlib.Path(dir_of_data) / 'test_trajectories_idtrackerai.npy'
-test_trajectories_path_border = pathlib.Path(dir_of_data) / 'test_trajectories_idtrackerai_with_border.npy'
-test_raw_trajectories_path = pathlib.Path(dir_of_data) / 'test_trajectories.npy'
-test_trajectories_with_points_path = pathlib.Path(dir_of_data) / 'trajectories_with_points.npy'
+test_trajectories_path = (
+    pathlib.Path(dir_of_data) / "test_trajectories_idtrackerai.npy"
+)
+test_trajectories_path_border = (
+    pathlib.Path(dir_of_data) / "test_trajectories_idtrackerai_with_border.npy"
+)
+test_raw_trajectories_path = (
+    pathlib.Path(dir_of_data) / "test_trajectories.npy"
+)
+test_trajectories_with_points_path = (
+    pathlib.Path(dir_of_data) / "trajectories_with_points.npy"
+)

--- a/trajectorytools/examples/animate.py
+++ b/trajectorytools/examples/animate.py
@@ -8,23 +8,21 @@ import trajectorytools.animation as ttanimation
 import trajectorytools.socialcontext as ttsocial
 from trajectorytools.constants import dir_of_data
 
-if __name__ == '__main__':
-    test_trajectories_file = os.path.join(dir_of_data, 'test_trajectories.npy')
+if __name__ == "__main__":
+    test_trajectories_file = os.path.join(dir_of_data, "test_trajectories.npy")
     t = np.load(test_trajectories_file)
     tt.center_trajectories_and_normalise(t)
     tt.interpolate_nans(t)
-    [s_,v_] = tt.smooth_several(t, derivatives=[0,1])
+    [s_, v_] = tt.smooth_several(t, derivatives=[0, 1])
     speed = tt.norm(v_)
-    colornorm = mpl.colors.Normalize(vmin = speed.min(), vmax = speed.max(), clip = True)
+    colornorm = mpl.colors.Normalize(
+        vmin=speed.min(), vmax=speed.max(), clip=True
+    )
     mapper = mpl.cm.ScalarMappable(norm=colornorm, cmap=mpl.cm.hot)
     color = mapper.to_rgba(speed)
-    anim1 = ttanimation.scatter_vectors(s_, velocities = v_, k = 10)
+    anim1 = ttanimation.scatter_vectors(s_, velocities=v_, k=10)
     anim2 = ttanimation.scatter_ellipses_color(s_, v_, color)
 
     anim = anim1 + anim2
     anim.prepare()
     anim.show()
-
-
-
-

--- a/trajectorytools/examples/animate.py
+++ b/trajectorytools/examples/animate.py
@@ -1,10 +1,11 @@
 import os
-import numpy as np
+
 import matplotlib as mpl
+import numpy as np
 
 import trajectorytools as tt
-import trajectorytools.plot as ttplot
 import trajectorytools.animation as ttanimation
+import trajectorytools.plot as ttplot
 import trajectorytools.socialcontext as ttsocial
 from trajectorytools.constants import dir_of_data
 

--- a/trajectorytools/examples/animate_border.py
+++ b/trajectorytools/examples/animate_border.py
@@ -6,15 +6,16 @@ import trajectorytools.animation as ttanimation
 import trajectorytools.socialcontext as ttsocial
 from trajectorytools.constants import test_raw_trajectories_path
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # Loading test trajectories as a numpy array of locations
     test_trajectories = np.load(test_raw_trajectories_path, allow_pickle=True)
 
     # We will process the numpy array, interpolate nans and smooth it.
     # To do this, we will use the Trajectories API
-    smooth_params = {'sigma': 1}
-    traj = tt.Trajectories.from_positions(test_trajectories,
-                                          smooth_params=smooth_params)
+    smooth_params = {"sigma": 1}
+    traj = tt.Trajectories.from_positions(
+        test_trajectories, smooth_params=smooth_params
+    )
 
     # We assume a circular arena and populate center and radius keys
     center, radius = traj.estimate_center_and_radius_from_locations()
@@ -27,7 +28,7 @@ if __name__ == '__main__':
 
     # We will change the time units to seconds. The video was recorded at 32
     # fps, so we do:
-    traj.new_time_unit(32, 'second')
+    traj.new_time_unit(32, "second")
 
     # Now we can find the smoothed trajectories, velocities and accelerations
     # in traj.s, traj.v and traj.a
@@ -36,9 +37,7 @@ if __name__ == '__main__':
     in_border = ttsocial.in_alpha_border(traj.s, alpha=5)
 
     # Animation showing the fish on the border
-    colornorm = mpl.colors.Normalize(vmin=0,
-                                     vmax=3,
-                                     clip=True)
+    colornorm = mpl.colors.Normalize(vmin=0, vmax=3, clip=True)
     mapper = mpl.cm.ScalarMappable(norm=colornorm, cmap=mpl.cm.RdBu)
     color = mapper.to_rgba(in_border)
 

--- a/trajectorytools/examples/animate_border.py
+++ b/trajectorytools/examples/animate_border.py
@@ -1,5 +1,5 @@
-import numpy as np
 import matplotlib as mpl
+import numpy as np
 
 import trajectorytools as tt
 import trajectorytools.animation as ttanimation

--- a/trajectorytools/examples/bouts_analysis.py
+++ b/trajectorytools/examples/bouts_analysis.py
@@ -1,6 +1,6 @@
-import os
 import numpy as np
 from matplotlib import pyplot as plt
+
 import trajectorytools as tt
 from trajectorytools.constants import test_trajectories_path
 

--- a/trajectorytools/examples/bouts_analysis.py
+++ b/trajectorytools/examples/bouts_analysis.py
@@ -8,38 +8,55 @@ from trajectorytools.constants import test_trajectories_path
 def plot_bouts(ax, starting_frame, focal, num_frames=220):
     time_range = (starting_frame, starting_frame + num_frames)
     frame_range = range(time_range[0], time_range[1], 1)
-    starting_bouts = np.squeeze(all_bouts[focal][
-        np.where((all_bouts[focal][:,0] > frame_range[0]) &
-                 ((all_bouts[focal][:,0] < frame_range[-1]))),0])
-    bout_peaks = np.squeeze(all_bouts[focal][
-        np.where((all_bouts[focal][:,1] > frame_range[0]) &
-                 ((all_bouts[focal][:,1] < frame_range[-1]))),1])
-    ax.plot(np.asarray(frame_range), tr.speed[frame_range, focal], c='b')
+    starting_bouts = np.squeeze(
+        all_bouts[focal][
+            np.where(
+                (all_bouts[focal][:, 0] > frame_range[0])
+                & ((all_bouts[focal][:, 0] < frame_range[-1]))
+            ),
+            0,
+        ]
+    )
+    bout_peaks = np.squeeze(
+        all_bouts[focal][
+            np.where(
+                (all_bouts[focal][:, 1] > frame_range[0])
+                & ((all_bouts[focal][:, 1] < frame_range[-1]))
+            ),
+            1,
+        ]
+    )
+    ax.plot(np.asarray(frame_range), tr.speed[frame_range, focal], c="b")
     for starting_bout in starting_bouts:
-        ax.axvline(x=starting_bout, c='g')
+        ax.axvline(x=starting_bout, c="g")
     for bout_peak in bout_peaks:
-        ax.axvline(x=bout_peak, c='r')
+        ax.axvline(x=bout_peak, c="r")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     # Loading a trajectory file produced by idtracker.ai
-    tr = tt.FishTrajectories.from_idtrackerai(test_trajectories_path,
-                                              smooth_params={'sigma': .5},
-                                              interpolate_nans=True)
+    tr = tt.FishTrajectories.from_idtrackerai(
+        test_trajectories_path,
+        smooth_params={"sigma": 0.5},
+        interpolate_nans=True,
+    )
 
-    find_max_dict = {'prominence': (0.2*tr.speed.std(), None),
-                     'distance': 3}
-    find_min_dict = {'prominence': (0.01*tr.speed.std(), None),
-                     'distance': 3}
+    find_max_dict = {"prominence": (0.2 * tr.speed.std(), None), "distance": 3}
+    find_min_dict = {
+        "prominence": (0.01 * tr.speed.std(), None),
+        "distance": 3,
+    }
     all_bouts = tr.get_bouts(find_max_dict, find_min_dict)
 
-    fig, ax = plt.subplots(tr.number_of_individuals, figsize=(20, 20), sharex=True, sharey=True)
+    fig, ax = plt.subplots(
+        tr.number_of_individuals, figsize=(20, 20), sharex=True, sharey=True
+    )
     for i in range(tr.number_of_individuals):
         plot_bouts(ax[i], 0, i)
         if i == tr.number_of_individuals - 1:
-            ax[i].set_xlabel('frame number', fontsize=14)
-            ax[i].set_ylabel('speed', fontsize=14)
+            ax[i].set_xlabel("frame number", fontsize=14)
+            ax[i].set_ylabel("speed", fontsize=14)
 
-    plt.subplots_adjust(hspace=1.)
+    plt.subplots_adjust(hspace=1.0)
     plt.show()

--- a/trajectorytools/examples/example.py
+++ b/trajectorytools/examples/example.py
@@ -1,8 +1,10 @@
 import os
-import numpy as np
+
 import matplotlib.pyplot as plt
-from trajectorytools.constants import dir_of_data
+import numpy as np
+
 import trajectorytools as tt
+from trajectorytools.constants import dir_of_data
 
 if __name__ == "__main__":
 

--- a/trajectorytools/examples/example.py
+++ b/trajectorytools/examples/example.py
@@ -4,10 +4,10 @@ import matplotlib.pyplot as plt
 from trajectorytools.constants import dir_of_data
 import trajectorytools as tt
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     # Loading a npy file and using trajectorytools normal API
-    test_trajectories_file = os.path.join(dir_of_data, 'test_trajectories.npy')
+    test_trajectories_file = os.path.join(dir_of_data, "test_trajectories.npy")
     t = np.load(test_trajectories_file, allow_pickle=True)
     tt.interpolate_nans(t)
     [s_, v_, a_] = tt.smooth_several(t, derivatives=[0, 1, 2])

--- a/trajectorytools/examples/follow_animate.py
+++ b/trajectorytools/examples/follow_animate.py
@@ -8,7 +8,7 @@ from trajectorytools.constants import dir_of_data
 
 def animate_and_follow(individual=0, num_neighbours=15):
     # Using the low level API
-    test_trajectories_file = os.path.join(dir_of_data, 'test_trajectories.npy')
+    test_trajectories_file = os.path.join(dir_of_data, "test_trajectories.npy")
     t = np.load(test_trajectories_file, allow_pickle=True)
     tt.interpolate_nans(t)
     tt.center_trajectories_and_normalise(t)
@@ -29,13 +29,13 @@ def animate_and_follow(individual=0, num_neighbours=15):
     vf = v[:, [individual], :]
 
     anim = ttanimation.scatter_vectors(s, velocities=v, k=10)
-    anim += ttanimation.scatter_ellipses(s, velocities=v, color='c')
-    anim += ttanimation.scatter_ellipses(sn, velocities=vn, color='b')
-    anim += ttanimation.scatter_ellipses(sf, velocities=vf, color='r')
+    anim += ttanimation.scatter_ellipses(s, velocities=v, color="c")
+    anim += ttanimation.scatter_ellipses(sn, velocities=vn, color="b")
+    anim += ttanimation.scatter_ellipses(sf, velocities=vf, color="r")
     anim += ttanimation.scatter_circle(center)
     anim.prepare()
     anim.show()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     animate_and_follow()

--- a/trajectorytools/examples/follow_animate.py
+++ b/trajectorytools/examples/follow_animate.py
@@ -1,5 +1,7 @@
 import os
+
 import numpy as np
+
 import trajectorytools as tt
 import trajectorytools.animation as ttanimation
 import trajectorytools.socialcontext as ttsocial

--- a/trajectorytools/fish_bouts/fish_bouts.py
+++ b/trajectorytools/fish_bouts/fish_bouts.py
@@ -2,19 +2,18 @@ import trajectorytools as tt
 
 
 def bout_statistics():
-
     def latency(tr, bout, focal):
-        return bout[2]-bout[0]
+        return bout[2] - bout[0]
 
     def acceleration_time(tr, bout, focal):
-        return bout[1]-bout[0]
+        return bout[1] - bout[0]
 
     def gliding_time(tr, bout, focal):
         """
         It can only be interpreted as gliding time if the end of the current bout
         coincides with the beginning of the next bout
         """
-        return bout[2]-bout[1]
+        return bout[2] - bout[1]
 
     def location_start(tr, bout, focal):
         return tr.s[bout[0], focal]
@@ -32,28 +31,41 @@ def bout_statistics():
         return tt.norm(tr.s[bout[2], focal] - tr.s[bout[0], focal])
 
     def turning_angle(tr, bout, focal):
-        return tt.signed_angle_between_vectors(tr.v[bout[1], focal], tr.v[bout[0], focal])
+        return tt.signed_angle_between_vectors(
+            tr.v[bout[1], focal], tr.v[bout[0], focal]
+        )
 
     def turning_angle_with_gliding(tr, bout, focal):
-        return tt.signed_angle_between_vectors(tr.v[bout[2], focal], tr.v[bout[0], focal])
+        return tt.signed_angle_between_vectors(
+            tr.v[bout[2], focal], tr.v[bout[0], focal]
+        )
 
     def turning_angle_old(tr, bout, focal):
-        return tt.angle_between_vectors(tr.v[bout[1], focal], tr.v[bout[0], focal])
+        return tt.angle_between_vectors(
+            tr.v[bout[1], focal], tr.v[bout[0], focal]
+        )
 
-    return [value for key, value in locals().items()
-            if callable(value) and not key.startswith('__')]
+    return [
+        value
+        for key, value in locals().items()
+        if callable(value) and not key.startswith("__")
+    ]
 
 
 def compute_bouts_parameters(tr, bouts, focal):
     variables = bout_statistics()
-    bouts_dict = {var.__name__: [var(tr, bout, focal) for bout in bouts]
-                  for var in variables}
-    bouts_dict['bouts'] = bouts
+    bouts_dict = {
+        var.__name__: [var(tr, bout, focal) for bout in bouts]
+        for var in variables
+    }
+    bouts_dict["bouts"] = bouts
     return bouts_dict
 
 
 def get_bouts_parameters(tr, find_max_dict=None, find_min_dict=None):
     all_bouts = tr.get_bouts(find_max_dict, find_min_dict)
-    indiv_bouts = [compute_bouts_parameters(tr, all_bouts[focal], focal)
-                   for focal in range(tr.number_of_individuals)]
+    indiv_bouts = [
+        compute_bouts_parameters(tr, all_bouts[focal], focal)
+        for focal in range(tr.number_of_individuals)
+    ]
     return indiv_bouts

--- a/trajectorytools/geometry.py
+++ b/trajectorytools/geometry.py
@@ -1,11 +1,12 @@
 import numpy as np
+
 EPSILON = 1e-16
 
 # SIMPLE TOOLS
 
 
 def dot(x, y, keepdims=False):
-    result = np.einsum('...i,...i->...', x, y)
+    result = np.einsum("...i,...i->...", x, y)
     if keepdims:
         return np.expand_dims(result, -1)
     else:
@@ -22,18 +23,18 @@ def cross2D(v, w, keepdims=False):
 def matrix_dot(matrix, data):
     if len(matrix.shape) == 2:
         # Same matrix for everyone
-        return np.einsum('ij,...j->...i', matrix, data)
+        return np.einsum("ij,...j->...i", matrix, data)
     elif len(matrix.shape) == 3:
         # Each frame has a matrix
-        return np.einsum('kij,k...j->k...i', matrix, data)
+        return np.einsum("kij,k...j->k...i", matrix, data)
     elif len(data.shape) == len(matrix.shape) - 1:
         # Each frame, individual (and maybe neighbour) has a matrix
-        return np.einsum('...ij,...j->...i', matrix, data)
+        return np.einsum("...ij,...j->...i", matrix, data)
     elif len(data.shape) == len(matrix.shape) == 4:
         # Each frame and individual has a matrix. There are neighbours but all use same matrix
-        return np.einsum('...ij,...kj->...ki', matrix, data)
+        return np.einsum("...ij,...kj->...ki", matrix, data)
     else:
-        raise Exception('matrix_dot: wrong input dimension')
+        raise Exception("matrix_dot: wrong input dimension")
 
 
 def norm(a, keepdims=False):
@@ -49,9 +50,10 @@ def normalise(a):
 
 def curvature(v, a):
     assert (v.shape[-1]) == 2
-    assert (np.all(v.shape == a.shape))
+    assert np.all(v.shape == a.shape)
     return (v[..., 0] * a[..., 1] - v[..., 1] * a[..., 0]) / np.power(
-        norm(v), 3)
+        norm(v), 3
+    )
 
 
 def distance_travelled(s):
@@ -63,7 +65,10 @@ def distance_travelled(s):
 
 def straightness(s, epsilon=EPSILON):
     norm_displacement = norm(s[-1] - s[0])
-    return (norm_displacement + epsilon) / (distance_travelled(s)[-1] + epsilon)
+    return (norm_displacement + epsilon) / (
+        distance_travelled(s)[-1] + epsilon
+    )
+
 
 # TOOLS FOR ROTATING
 
@@ -97,23 +102,23 @@ def center_in_individual(data, individual):
 
 
 def angle_between_vectors(x, y):
-    '''Angle between vectors, between 0 and pi radians, no sign
-    '''
+    """Angle between vectors, between 0 and pi radians, no sign
+    """
     u, v = normalise(x), normalise(y)
     return np.arccos(np.clip(dot(u, v), -1.0, +1.0))
 
 
 def signed_angle_between_vectors(x, y):
-    '''A different algorithms to calculate angle between vectors,
+    """A different algorithms to calculate angle between vectors,
     between -pi and pi radians
-    '''
+    """
     angle = np.arctan2(y[..., 1], y[..., 0]) - np.arctan2(x[..., 1], x[..., 0])
     return (angle + np.pi) % (2 * np.pi) - np.pi
 
 
 def _ey_to_ex(e_):
-    '''Takes a vector and rotates it -90 degrees
-    it takes a unit vector ey into ex'''
+    """Takes a vector and rotates it -90 degrees
+    it takes a unit vector ey into ex"""
     ex = np.empty_like(e_)
     ex[..., 1] = -e_[..., 0]
     ex[..., 0] = e_[..., 1]

--- a/trajectorytools/geometry.py
+++ b/trajectorytools/geometry.py
@@ -31,7 +31,8 @@ def matrix_dot(matrix, data):
         # Each frame, individual (and maybe neighbour) has a matrix
         return np.einsum("...ij,...j->...i", matrix, data)
     elif len(data.shape) == len(matrix.shape) == 4:
-        # Each frame and individual has a matrix. There are neighbours but all use same matrix
+        # Each frame and individual has a matrix. There are neighbours
+        # but all neighbours use same matrix
         return np.einsum("...ij,...kj->...ki", matrix, data)
     else:
         raise Exception("matrix_dot: wrong input dimension")

--- a/trajectorytools/interpolate.py
+++ b/trajectorytools/interpolate.py
@@ -1,10 +1,10 @@
-import sys
-import traceback
 import logging
-import numpy as np
-from scipy.ndimage.filters import gaussian_filter1d, convolve1d
-from scipy import signal
+import traceback
 import warnings
+
+import numpy as np
+from scipy import signal
+from scipy.ndimage.filters import convolve1d, gaussian_filter1d
 
 
 def interpolate_nans(t):

--- a/trajectorytools/plot/plot.py
+++ b/trajectorytools/plot/plot.py
@@ -1,8 +1,8 @@
-import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt
-from matplotlib.patches import Ellipse, Circle
+import numpy as np
 from matplotlib.lines import Line2D
+from matplotlib.patches import Circle, Ellipse
 
 # Scene
 

--- a/trajectorytools/plot/plot.py
+++ b/trajectorytools/plot/plot.py
@@ -6,146 +6,184 @@ from matplotlib.lines import Line2D
 
 # Scene
 
+
 class Fish:
-    default_ellipse_params = {'width': 1, 'height':1/2,
-                              'fc': 'b', 'ec': 'k',
-                              'linewidth': 0.03}
-    def __init__(self, xy, v, restricted=False, ellipse_params=None,
-                 color = 'k', marker_size = 0.04, vel_factor = 10,
-                 velocity_marker = True):
+    default_ellipse_params = {
+        "width": 1,
+        "height": 1 / 2,
+        "fc": "b",
+        "ec": "k",
+        "linewidth": 0.03,
+    }
+
+    def __init__(
+        self,
+        xy,
+        v,
+        restricted=False,
+        ellipse_params=None,
+        color="k",
+        marker_size=0.04,
+        vel_factor=10,
+        velocity_marker=True,
+    ):
         self._xy = xy
         self._v = v
         self.vel_factor = vel_factor
         self.restricted = restricted
 
-        if ellipse_params is None: ellipse_params = {}
+        if ellipse_params is None:
+            ellipse_params = {}
         ellipse_params = {**self.default_ellipse_params, **ellipse_params}
-        ellipse_params['angle'] = np.degrees(np.arctan2(v[1],v[0]))
+        ellipse_params["angle"] = np.degrees(np.arctan2(v[1], v[0]))
         self.body = Ellipse(xy=xy, **ellipse_params)
-        self.velocity_line = Line2D([xy[0], self.xy_vel[0]], [xy[1], self.xy_vel[1]],
-                                    color = color, linewidth = 0.4)
+        self.velocity_line = Line2D(
+            [xy[0], self.xy_vel[0]],
+            [xy[1], self.xy_vel[1]],
+            color=color,
+            linewidth=0.4,
+        )
         self.artists = [self.body, self.velocity_line]
         if velocity_marker:
-            self.velocity_marker = Circle(xy = self.xy_vel, radius = marker_size/10, fc = 'k')
+            self.velocity_marker = Circle(
+                xy=self.xy_vel, radius=marker_size / 10, fc="k"
+            )
             self.artists += [self.velocity_marker]
+
     @property
     def xy_vel(self):
-        return self.position + self.velocity*self.vel_factor
+        return self.position + self.velocity * self.vel_factor
+
     @property
     def figure(self):
         return self.body.figure
+
     @property
     def position(self):
-        return self._xy #self.body.center
+        return self._xy  # self.body.center
+
     @position.setter
     def position(self, xy):
         if not self.restricted:
             self._xy = xy
             self.body.center = xy
             self.velocity_marker.center = self.xy_vel
-            self.velocity_line.set_data([xy[0], self.xy_vel[0]], [xy[1], self.xy_vel[1]])
+            self.velocity_line.set_data(
+                [xy[0], self.xy_vel[0]], [xy[1], self.xy_vel[1]]
+            )
             self.body.stale = True
+
     @property
     def velocity(self):
-        return self._v #self.body.center
+        return self._v  # self.body.center
+
     @velocity.setter
     def velocity(self, v):
         if self.restricted:
             v = v.copy()
-            v[1] = max(0,v[1])
+            v[1] = max(0, v[1])
             v[0] = 0.0
         self._v = v
-        self.body.angle = np.degrees(np.arctan2(v[1],v[0]))
-        self.velocity_marker.center = self.position + v*self.vel_factor
-        self.velocity_line.set_data([self.position[0], self.xy_vel[0]], [self.position[1], self.xy_vel[1]])
+        self.body.angle = np.degrees(np.arctan2(v[1], v[0]))
+        self.velocity_marker.center = self.position + v * self.vel_factor
+        self.velocity_line.set_data(
+            [self.position[0], self.xy_vel[0]],
+            [self.position[1], self.xy_vel[1]],
+        )
         self.body.stale = True
+
     def add_to_axis(self, ax):
         for artist in self.artists:
             ax.add_artist(artist)
             artist.set_clip_box(ax.bbox)
         self.velocity_line.axes = ax
-        self.axes = ax #self.body.axes
+        self.axes = ax  # self.body.axes
+
 
 class Scene:
-    def __init__(self, fish, ax, target=None, focal_acceleration=False, vel_factor=0.3):
+    def __init__(
+        self, fish, ax, target=None, focal_acceleration=False, vel_factor=0.3
+    ):
         for f in fish:
-            fish_artist = Fish(f['position'], f['velocity'],
-                               ellipse_params = f['ellipse'],
-                               vel_factor=vel_factor)
+            fish_artist = Fish(
+                f["position"],
+                f["velocity"],
+                ellipse_params=f["ellipse"],
+                vel_factor=vel_factor,
+            )
             fish_artist.add_to_axis(ax)
         if target is not None:
-            ax.add_artist(plt.Circle((target[0], target[1]), 0.05, color='k'))
+            ax.add_artist(plt.Circle((target[0], target[1]), 0.05, color="k"))
         if focal_acceleration is not None:
-            ax.plot([0,focal_acceleration[0]],[0,focal_acceleration[1]],
-                    'k', linewidth=0.03)
+            ax.plot(
+                [0, focal_acceleration[0]],
+                [0, focal_acceleration[1]],
+                "k",
+                linewidth=0.03,
+            )
 
     @classmethod
-    def from_frame(cls, frame, ax, color=None, edgecolor=None,
-                   body_length=1, target=None, focal_acceleration=True,
-                   vel_factor=0.3):
-        assert(len(frame.shape) == 2)
+    def from_frame(
+        cls,
+        frame,
+        ax,
+        color=None,
+        edgecolor=None,
+        body_length=1,
+        target=None,
+        focal_acceleration=True,
+        vel_factor=0.3,
+    ):
+        assert len(frame.shape) == 2
         fish = []
         for i in range(frame.shape[0]):
-            new_fish = {'position': np.array([frame[i, 0], frame[i, 1]]),
-                         'velocity': np.array([frame[i, 2], frame[i, 3]])}
+            new_fish = {
+                "position": np.array([frame[i, 0], frame[i, 1]]),
+                "velocity": np.array([frame[i, 2], frame[i, 3]]),
+            }
             if color is not None and color[i] is not None:
-                new_fish['ellipse'] = {'fc': color[i],
-                                       'width': body_length,
-                                       'height': 0.5*body_length}
+                new_fish["ellipse"] = {
+                    "fc": color[i],
+                    "width": body_length,
+                    "height": 0.5 * body_length,
+                }
 
             fish.append(new_fish)
         if focal_acceleration:
-            focal_acceleration = frame[0, 4:] #*DELTA_A*0.3
+            focal_acceleration = frame[0, 4:]  # *DELTA_A*0.3
         else:
-            focal_acceleration=None
+            focal_acceleration = None
 
-        return cls(fish, ax, target=target, vel_factor=vel_factor,
-                   focal_acceleration=focal_acceleration)
-
-
-
-
-#@classmethod
-    #def from_frame(cls, frame, ax, color=None, edgecolor=None, target=None, focal_acceleration=True):
-    #    assert(len(frame.shape) == 2)
-    #    fish = []
-    #    for i in range(frame.shape[0]):
-    #        new_fish = {'position': [frame[i, 0]*DELTA_X,
-    #                                  frame[i, 1]*DELTA_X],
-    #                     'velocity': [frame[i, 2]*DELTA_V,
-    #                                  frame[i, 3]*DELTA_V]}
-    #        if color is not None and color[i] is not None:
-    #            new_fish.update({'color': color[i]})
-    #        #if edgecolor is not None and edgecolor[i] is not None:
-    #        #    new_fish.update({'edgecolor': edgecolor[i]})
-    #        fish.append(new_fish)
-    #    if target is not None:
-    #        target *= DELTA_X
-    #    if focal_acceleration:
-    #        focal_acceleration = frame[0, 4:]*DELTA_A*0.3
-    #    else:
-    #        focal_acceleration=None
-
-    #    return cls(fish, ax, target=target, focal_acceleration=focal_acceleration)
+        return cls(
+            fish,
+            ax,
+            target=target,
+            vel_factor=vel_factor,
+            focal_acceleration=focal_acceleration,
+        )
 
 
 ### Histogram / diagram stuff below
 
-def get_spaced_colors(n, cmap = 'jet'):
+
+def get_spaced_colors(n, cmap="jet"):
     RGB_tuples = matplotlib.cm.get_cmap(cmap)
     return [RGB_tuples(i / n) for i in range(n)]
+
 
 def subplots_row_and_colums(number_of_individuals):
     number_of_columns = int(np.sqrt(number_of_individuals))
     number_of_rows = int(np.ceil(number_of_individuals / number_of_columns))
     return number_of_rows, number_of_columns
 
+
 def no_ticks(ax):
     ax.set_yticklabels([]), ax.set_yticks([])
     ax.set_xticklabels([]), ax.set_xticks([])
 
+
 def with_ordering(old_func):
-    def new_func(scalar_or_vector, order_by = None, indices = None, **kwargs):
+    def new_func(scalar_or_vector, order_by=None, indices=None, **kwargs):
         number_of_individuals = scalar_or_vector.shape[1]
         if order_by is None:
             if indices is None:
@@ -154,38 +192,57 @@ def with_ordering(old_func):
             if indices is None:
                 indices = np.argsort(order_by)
             else:
-                print("Warning! Giving both indices and order_by. Taking indices")
+                print(
+                    "Warning! Giving both indices and order_by. Taking indices"
+                )
         return old_func(scalar_or_vector, indices, **kwargs)
+
     return new_func
 
+
 @with_ordering
-def plot_individual_distribution(variable, indices, nbins = 25, ticks = False):
+def plot_individual_distribution(variable, indices, nbins=25, ticks=False):
     number_of_individuals = len(indices)
-    number_of_rows, number_of_columns = subplots_row_and_colums(number_of_individuals)
-    fig, ax_arr = plt.subplots(number_of_rows, number_of_columns, sharex = True, sharey = True)
+    number_of_rows, number_of_columns = subplots_row_and_colums(
+        number_of_individuals
+    )
+    fig, ax_arr = plt.subplots(
+        number_of_rows, number_of_columns, sharex=True, sharey=True
+    )
     min_variable = np.min(variable)
     max_variable = np.percentile(variable, 99)
     bins = np.linspace(min_variable, max_variable, nbins)
     for i, identity in enumerate(indices):
-        ax = ax_arr[int(i/number_of_columns), i%number_of_columns]
-        n, bins_edges = np.histogram(variable[:,identity], bins = bins)
+        ax = ax_arr[int(i / number_of_columns), i % number_of_columns]
+        n, bins_edges = np.histogram(variable[:, identity], bins=bins)
         ax.plot(bins_edges[:-1] + np.diff(bins_edges)[0], n)
         if ticks is False:
             no_ticks(ax)
-            ax.spines['top'].set_visible(False)
-            ax.spines['right'].set_visible(False)
+            ax.spines["top"].set_visible(False)
+            ax.spines["right"].set_visible(False)
     return fig
 
+
 @with_ordering
-def plot_individual_distribution_of_vector(vector, indices, nbins = 10, ticks = False):
+def plot_individual_distribution_of_vector(
+    vector, indices, nbins=10, ticks=False
+):
     if np.isnan(vector).any():
-        print('Removing NaNs from data')
+        print("Removing NaNs from data")
     number_of_individuals = len(indices)
-    number_of_rows, number_of_columns = subplots_row_and_colums(number_of_individuals)
+    number_of_rows, number_of_columns = subplots_row_and_colums(
+        number_of_individuals
+    )
     fig, ax_arr = plt.subplots(number_of_rows, number_of_columns)
     v_max = 0
-    min_x, max_x = np.percentile(vector[:,:,0][~np.isnan(vector[:,:,0])],1), np.percentile(vector[:,:,0][~np.isnan(vector[:,:,0])],99)
-    min_y, max_y = np.percentile(vector[:,:,1][~np.isnan(vector[:,:,1])],1), np.percentile(vector[:,:,1][~np.isnan(vector[:,:,1])],99)
+    min_x, max_x = (
+        np.percentile(vector[:, :, 0][~np.isnan(vector[:, :, 0])], 1),
+        np.percentile(vector[:, :, 0][~np.isnan(vector[:, :, 0])], 99),
+    )
+    min_y, max_y = (
+        np.percentile(vector[:, :, 1][~np.isnan(vector[:, :, 1])], 1),
+        np.percentile(vector[:, :, 1][~np.isnan(vector[:, :, 1])], 99),
+    )
     print("X from {} to {}".format(min_x, max_x))
     print("Y from {} to {}".format(min_y, max_y))
     binsX = np.linspace(min_x, max_x, nbins)
@@ -193,35 +250,24 @@ def plot_individual_distribution_of_vector(vector, indices, nbins = 10, ticks = 
     ax = []
     H = []
     for i, identity in enumerate(indices):
-        ax.append(ax_arr[int(i/number_of_columns), i%number_of_columns])
-        H.append(np.histogram2d(vector[:,identity,0][~np.isnan(vector[:,identity,0])].flatten(), vector[:,identity,1][~np.isnan(vector[:,identity,1])].flatten(), bins=(binsX, binsY))[0])
+        ax.append(ax_arr[int(i / number_of_columns), i % number_of_columns])
+        H.append(
+            np.histogram2d(
+                vector[:, identity, 0][
+                    ~np.isnan(vector[:, identity, 0])
+                ].flatten(),
+                vector[:, identity, 1][
+                    ~np.isnan(vector[:, identity, 1])
+                ].flatten(),
+                bins=(binsX, binsY),
+            )[0]
+        )
         v_max = max(v_max, H[i].max())
     for i, H_i in enumerate(H):
-        ax[i].imshow(H_i, vmin = 0, vmax = v_max, cmap = 'jet')
-        ax[i].set_title(str(indices[i] + 1), fontsize = 8)
+        ax[i].imshow(H_i, vmin=0, vmax=v_max, cmap="jet")
+        ax[i].set_title(str(indices[i] + 1), fontsize=8)
         print(ax[i].get_xlim(), ax[i].get_ylim())
         # ax[i].set_title(str(indices[i]))
         if ticks is False:
             no_ticks(ax[i])
     return fig
-
-## Old scripts for removal below
-import warnings
-#
-#def histogram(v, ax):
-#    valid = np.logical_not(np.isnan(v[:]))
-#    vv = v[valid]
-#    ax.hist(vv)
-#    warnings.warn("Fraction to be removed!", DeprecationWarning)
-#
-def position_histogram(trajectories):
-   warnings.warn("Fuction to be removed!", DeprecationWarning)
-   nbinsX = 100
-   nbinsY = 100
-   histogram2d = np.zeros((nbinsX, nbinsY))
-   for i in range(trajectories.shape[1]):
-       H, xedges, yedges = np.histogram2d(trajectories[:,i,0], trajectories[:,i,1], bins=(nbinsX, nbinsY))
-       histogram2d += H
-
-   average_histogram_2d = histogram2d / trajectories.shape[1]
-   return average_histogram_2d

--- a/trajectorytools/socialcontext/leadership.py
+++ b/trajectorytools/socialcontext/leadership.py
@@ -1,5 +1,7 @@
 import numpy as np
+
 import trajectorytools as tt
+
 from .socialcontext import restrict
 
 
@@ -199,7 +201,7 @@ def dot_product_with_delays_slow(
     data, indices, sweeped_delays, frame, inplace=None
 ):
     # Only for debugging
-    num_restricted = indices.shape[-1]
+    indices.shape[-1]
     num_individuals = data.shape[1]
     max_delay = sweeped_delays.shape[0]
     if inplace is None:

--- a/trajectorytools/socialcontext/leadership.py
+++ b/trajectorytools/socialcontext/leadership.py
@@ -26,21 +26,33 @@ def restrict_with_delay(data, indices, individual=None, delay=0):
 
 
 def sweep_delays(data, indices, max_delay, individual=None):
-    ''' This function sweeps delays of whole data
+    """ This function sweeps delays of whole data
     and outputs an array with an extra dimension
-    '''
+    """
     num_restricted = indices.shape[-1]
     total_time_steps = data.shape[0] - max_delay
     num_individuals = data.shape[1]
     coordinates = data.shape[-1]
     if individual is None:
-        output = np.empty([max_delay, total_time_steps, num_individuals,
-                           num_restricted, coordinates], dtype=data.dtype)
+        output = np.empty(
+            [
+                max_delay,
+                total_time_steps,
+                num_individuals,
+                num_restricted,
+                coordinates,
+            ],
+            dtype=data.dtype,
+        )
     else:
-        output = np.empty([max_delay, total_time_steps,
-                           num_restricted, coordinates], dtype=data.dtype)
+        output = np.empty(
+            [max_delay, total_time_steps, num_restricted, coordinates],
+            dtype=data.dtype,
+        )
     for delay in range(max_delay):
-        delayed_restricted = restrict_with_delay(data, indices, delay=delay, individual=individual)
+        delayed_restricted = restrict_with_delay(
+            data, indices, delay=delay, individual=individual
+        )
         output[delay, ...] = delayed_restricted[:total_time_steps]
     return output
 
@@ -56,12 +68,16 @@ def sweep_delayed_orientation_with_neighbours(orientation, indices, max_delay):
     sweep_delay_P = tt.collective.polarization(sweep_delay_e)
     # dimensions: delay x time x num_individuals x 2
     restricted_orientation = orientation[:total_time_steps]
-    projected_orientation = np.einsum('...j,i...j->i...', restricted_orientation, sweep_delay_P)
+    projected_orientation = np.einsum(
+        "...j,i...j->i...", restricted_orientation, sweep_delay_P
+    )
     # dimensions: delay x time x num_individuals
     return projected_orientation, sweep_delay_e
 
 
-def dot_product_per_frame_with_delays(data, indices, sweeped_delays, frame, inplace=None):
+def dot_product_per_frame_with_delays(
+    data, indices, sweeped_delays, frame, inplace=None
+):
     """
 
     :param data: array of orientations (total_frames, num_individuals, 2)
@@ -75,22 +91,37 @@ def dot_product_per_frame_with_delays(data, indices, sweeped_delays, frame, inpl
     num_individuals = data.shape[1]
     max_delay = sweeped_delays.shape[0]
     if inplace is None:
-        inplace = np.zeros([max_delay, num_individuals, num_individuals], dtype=data.dtype)
+        inplace = np.zeros(
+            [max_delay, num_individuals, num_individuals], dtype=data.dtype
+        )
     for i in range(num_individuals):
         sweeped_delays_r = sweeped_delays[:, frame, i, :]
         orientation_r = data[frame, i]
-        inplace[:, i, indices[frame, i]] += np.einsum('ijk,k->ij', sweeped_delays_r, orientation_r)
+        inplace[:, i, indices[frame, i]] += np.einsum(
+            "ijk,k->ij", sweeped_delays_r, orientation_r
+        )
     return inplace
 
 
 def dot_product_with_delays(data, indices, sweep_delayed_e, frames):
-    inplace = dot_product_per_frame_with_delays(data, indices, sweep_delayed_e, frames[0])
+    inplace = dot_product_per_frame_with_delays(
+        data, indices, sweep_delayed_e, frames[0]
+    )
     for frame in frames[1:]:
-        inplace = dot_product_per_frame_with_delays(data, indices, sweep_delayed_e, frame, inplace=inplace)
-    return inplace/len(frames)
+        inplace = dot_product_per_frame_with_delays(
+            data, indices, sweep_delayed_e, frame, inplace=inplace
+        )
+    return inplace / len(frames)
 
 
-def sliding_average_dot_product_with_delays(data, indices, sweep_delayed_e, start_frame=0, end_frame=None, window_size=50):
+def sliding_average_dot_product_with_delays(
+    data,
+    indices,
+    sweep_delayed_e,
+    start_frame=0,
+    end_frame=None,
+    window_size=50,
+):
     """
 
     :param data: array of orientations (total_frames, num_individuals, 2)
@@ -102,54 +133,82 @@ def sliding_average_dot_product_with_delays(data, indices, sweep_delayed_e, star
     :return:
     """
     assert end_frame + window_size < data.shape[0]
-    frames = range(start_frame, end_frame+window_size)
-    fleshout_list = [dot_product_per_frame_with_delays(data, indices, sweep_delayed_e, frame) for frame in frames]
-    return [sum(fleshout_list[i:(i+window_size)])/window_size for i in range(end_frame-start_frame)]
+    frames = range(start_frame, end_frame + window_size)
+    fleshout_list = [
+        dot_product_per_frame_with_delays(
+            data, indices, sweep_delayed_e, frame
+        )
+        for frame in frames
+    ]
+    return [
+        sum(fleshout_list[i : (i + window_size)]) / window_size
+        for i in range(end_frame - start_frame)
+    ]
 
 
-def sliding_average_dot_product_with_delays2(data, indices, sweep_delayed_e, start_frame=0, end_frame=None, num_frames_to_average = 50):
+def sliding_average_dot_product_with_delays2(
+    data,
+    indices,
+    sweep_delayed_e,
+    start_frame=0,
+    end_frame=None,
+    num_frames_to_average=50,
+):
     max_delay = sweep_delayed_e.shape[0]
-    frames = range(start_frame, end_frame+num_frames_to_average)
+    frames = range(start_frame, end_frame + num_frames_to_average)
     ## The 2-by-2 xcorrelation in sparse matrix: max delay x num_individuals x num_individuals
-    fleshout_list = [dot_product_per_frame_with_delays(data, indices, sweep_delayed_e, frame) for frame in frames]
+    fleshout_list = [
+        dot_product_per_frame_with_delays(
+            data, indices, sweep_delayed_e, frame
+        )
+        for frame in frames
+    ]
     ## A binary matrix (num_individuals x num_individuals) telling us whether individuals are neighbours in a given frame
-    connection_matrix_list = [give_connection_matrix(indices[frame]) for frame in frames]
+    connection_matrix_list = [
+        give_connection_matrix(indices[frame]) for frame in frames
+    ]
     output = []
-    for i in range(end_frame-start_frame):
-        sum_fleshout = sum(fleshout_list[i:(i+num_frames_to_average)])
-        sum_connections = sum(connection_matrix_list[i:(i+num_frames_to_average)])
+    for i in range(end_frame - start_frame):
+        sum_fleshout = sum(fleshout_list[i : (i + num_frames_to_average)])
+        sum_connections = sum(
+            connection_matrix_list[i : (i + num_frames_to_average)]
+        )
         for t in range(max_delay):
-            sum_fleshout[t][np.where(sum_connections>0)] /= sum_connections[np.where(sum_connections>0)]
+            sum_fleshout[t][np.where(sum_connections > 0)] /= sum_connections[
+                np.where(sum_connections > 0)
+            ]
         output.append(sum_fleshout)
     return output
 
 
-def give_connection_matrix(indices_in_frame, inplace = None):
+def give_connection_matrix(indices_in_frame, inplace=None):
     num_individuals = indices_in_frame.shape[0]
     if inplace is None:
         connection_matrix = np.zeros([num_individuals, num_individuals])
     else:
         connection_matrix = inplace
     for i in range(num_individuals):
-        connection_matrix[i, indices_in_frame[i,:]] += 1.0
+        connection_matrix[i, indices_in_frame[i, :]] += 1.0
     return connection_matrix
+
 
 # For debugging
 
 
-def dot_product_with_delays_slow(data, indices, sweeped_delays, frame, inplace = None):
+def dot_product_with_delays_slow(
+    data, indices, sweeped_delays, frame, inplace=None
+):
     # Only for debugging
     num_restricted = indices.shape[-1]
     num_individuals = data.shape[1]
     max_delay = sweeped_delays.shape[0]
     if inplace is None:
-        inplace = np.zeros([max_delay, num_individuals, num_individuals], dtype=data.dtype)
+        inplace = np.zeros(
+            [max_delay, num_individuals, num_individuals], dtype=data.dtype
+        )
     for i in range(num_individuals):
-        for ij,j in enumerate(indices[frame, i]):
-            sweep_delays_r = sweeped_delays[:,frame,i,ij]
-            orientation = data[frame,i]
-            inplace[:,i,j] += tt.dot(sweep_delays_r, orientation)
+        for ij, j in enumerate(indices[frame, i]):
+            sweep_delays_r = sweeped_delays[:, frame, i, ij]
+            orientation = data[frame, i]
+            inplace[:, i, j] += tt.dot(sweep_delays_r, orientation)
     return inplace
-
-
-

--- a/trajectorytools/socialcontext/leadership.py
+++ b/trajectorytools/socialcontext/leadership.py
@@ -10,7 +10,8 @@ def restrict_with_delay(data, indices, individual=None, delay=0):
 
     :param data: np.array with dimensions time x individuals x coordinates
     :param indices: np.array with dimensions time x individuals x subset_of_individuals
-    :param individual: label of individual to calculate restriction with delay. If None, calculating for all individuals
+    :param individual: label of individual to calculate restriction 
+    with delay. If None, calculating for all individuals
     :param delay:
 
     This function works as ttsocial.restrict, but
@@ -82,9 +83,12 @@ def dot_product_per_frame_with_delays(
 ):
     """
 
-    :param data: array of orientations (total_frames, num_individuals, 2)
-    :param indices: indices of neighbours (total_frames, num_individuals, num_individuals-1)
-    :param sweeped_delays: arrays of sweeped orientations with lag (num_delays, total_frames-num_delays, num_individuals, num_individuals-1, 2)
+    :param data: array of orientations 
+    (total_frames, num_individuals, 2)
+    :param indices: indices of neighbours 
+    (total_frames, num_individuals, num_individuals-1)
+    :param sweeped_delays: arrays of sweeped orientations with lag 
+    (num_delays, total_frames-num_delays, num_individuals, num_individuals-1, 2)
     :param frame: frame to compute
     :param inplace: (num_delays, num_individuals, num_individual)
     :return: (num_delays, num_individuals, num_individual)
@@ -126,9 +130,12 @@ def sliding_average_dot_product_with_delays(
 ):
     """
 
-    :param data: array of orientations (total_frames, num_individuals, 2)
-    :param indices: indices of neighbours (total_frames, num_individuals, num_individuals-1)
-    :param sweep_delayed_e: arrays of sweeped orientations with lag (num_delays, total_frames-num_delays, num_individuals, num_individuals-1, 2)
+    :param data: array of orientations with shape
+    (total_frames, num_individuals, 2)
+    :param indices: indices of neighbours with shape
+    (total_frames, num_individuals, num_individuals-1)
+    :param sweep_delayed_e: arrays of sweeped orientations with lag 
+    (num_delays, total_frames-num_delays, num_individuals, num_individuals-1, 2)
     :param start_frame: 0
     :param end_frame:
     :param window_size:
@@ -158,14 +165,16 @@ def sliding_average_dot_product_with_delays2(
 ):
     max_delay = sweep_delayed_e.shape[0]
     frames = range(start_frame, end_frame + num_frames_to_average)
-    ## The 2-by-2 xcorrelation in sparse matrix: max delay x num_individuals x num_individuals
+    # The 2-by-2 xcorrelation in sparse matrix:
+    # max delay x num_individuals x num_individuals
     fleshout_list = [
         dot_product_per_frame_with_delays(
             data, indices, sweep_delayed_e, frame
         )
         for frame in frames
     ]
-    ## A binary matrix (num_individuals x num_individuals) telling us whether individuals are neighbours in a given frame
+    # A binary matrix (num_individuals x num_individuals)
+    # telling us whether individuals are neighbours in a given frame
     connection_matrix_list = [
         give_connection_matrix(indices[frame]) for frame in frames
     ]

--- a/trajectorytools/socialcontext/socialcontext.py
+++ b/trajectorytools/socialcontext/socialcontext.py
@@ -142,9 +142,11 @@ def interindividual_distances(positions):
 def restrict(data, indices, individual=None):
     """restrict_with_delay
 
-    :param data: np.array with dimensions time x individuals x coordinates
-    :param indices: np.array with dimensions time x individuals x subset_of_individuals
-    :param individual: label of individual to calculate restriction with delay. If None, calculating for all individuals
+    :param data: np.array with shape time x individuals x coordinates
+    :param indices: np.array with shape 
+    time x individuals x subset_of_individuals
+    :param individual: label of individual to calculate restriction 
+    with delay. If None, calculating for all individuals
     """
     num_restricted = indices.shape[-1]
     total_time_steps = data.shape[0]

--- a/trajectorytools/socialcontext/socialcontext.py
+++ b/trajectorytools/socialcontext/socialcontext.py
@@ -19,12 +19,12 @@ def in_convex_hull(positions):
 
 
 def circumradius(points):
-    '''Radius of the circumcentre
+    """Radius of the circumcentre
     defined by three points.
-    '''
+    """
     # Sides of triangles
     side_vectors = points - np.roll(points, 1, axis=-2)
-    sides = np.sqrt(side_vectors[..., 0]**2 + side_vectors[..., 1]**2)
+    sides = np.sqrt(side_vectors[..., 0] ** 2 + side_vectors[..., 1] ** 2)
     a = sides[..., 0]
     b = sides[..., 1]
     c = sides[..., 2]
@@ -34,23 +34,26 @@ def circumradius(points):
 
 
 def _in_alpha_border(positions, alpha=5):
-    '''Calculate vertices in border of alpha-shape
+    """Calculate vertices in border of alpha-shape
     by pruning a Delaunay triangulation.
 
     Border points are either:
     1. In convex hull
     2. In rejected triangles
-    '''
+    """
+
     def radius_too_large(triangles):
         return circumradius(triangles) > 1 / alpha
 
     num_individuals, _ = positions.shape
     delaunay = scipy.spatial.Delaunay(positions)
     triangles = np.array(
-        [positions[triangle] for triangle in delaunay.simplices])
+        [positions[triangle] for triangle in delaunay.simplices]
+    )
     rejected_triangles = radius_too_large(triangles)
     points_in_rejected_triangles = [
-        p for triangle in delaunay.simplices[rejected_triangles]
+        p
+        for triangle in delaunay.simplices[rejected_triangles]
         for p in triangle
     ]
     in_border = np.zeros(num_individuals, np.bool)
@@ -70,12 +73,12 @@ def in_alpha_border(positions, alpha=5):
 # LOCAL NEIGHBOURS
 
 
-def _neighbours_indices_in_frame(positions,
-                                 num_neighbours,
-                                 adjacency=False,
-                                 mode='connectivity'):
-    nbrs = NearestNeighbors(n_neighbors=num_neighbours + 1,
-                            algorithm='ball_tree').fit(positions)
+def _neighbours_indices_in_frame(
+    positions, num_neighbours, adjacency=False, mode="connectivity"
+):
+    nbrs = NearestNeighbors(
+        n_neighbors=num_neighbours + 1, algorithm="ball_tree"
+    ).fit(positions)
     if adjacency:
         return nbrs.kneighbors_graph(positions, mode=mode).toarray()
     else:
@@ -86,46 +89,54 @@ def give_indices(positions, num_neighbours):
     total_time_steps = positions.shape[0]
     individuals = positions.shape[1]
     next_neighbours = np.empty(
-        [total_time_steps, individuals, num_neighbours + 1], dtype=np.int)
+        [total_time_steps, individuals, num_neighbours + 1], dtype=np.int
+    )
     for frame in range(total_time_steps):
         next_neighbours[frame, ...] = _neighbours_indices_in_frame(
-            positions[frame], num_neighbours)
+            positions[frame], num_neighbours
+        )
     return next_neighbours
 
 
-def adjacency_matrix(positions,
-                     num_neighbours=None,
-                     mode='connectivity',
-                     use_pdist_if_all_nb=True):
+def adjacency_matrix(
+    positions,
+    num_neighbours=None,
+    mode="connectivity",
+    use_pdist_if_all_nb=True,
+):
     total_time_steps = positions.shape[0]
     individuals = positions.shape[1]
     if num_neighbours is None:
         num_neighbours = individuals - 1
-    if mode == 'connectivity':
-        adjacency_m = np.empty([total_time_steps, individuals, individuals],
-                               dtype=np.bool)
-    elif mode == 'distance':
-        adjacency_m = np.empty([total_time_steps, individuals, individuals],
-                               dtype=positions.dtype)
+    if mode == "connectivity":
+        adjacency_m = np.empty(
+            [total_time_steps, individuals, individuals], dtype=np.bool
+        )
+    elif mode == "distance":
+        adjacency_m = np.empty(
+            [total_time_steps, individuals, individuals], dtype=positions.dtype
+        )
     else:
         raise ValueError("mode should be 'connectivity' or 'distance'")
 
     if (num_neighbours == individuals - 1) and use_pdist_if_all_nb:
-        if mode == 'connectivity':
+        if mode == "connectivity":
             adjacency_m[...] = True
         else:
             for frame in range(total_time_steps):
                 adjacency_m[frame, ...] = spdist.squareform(
-                    spdist.pdist(positions[frame]))
+                    spdist.pdist(positions[frame])
+                )
     else:
         for frame in range(total_time_steps):
             adjacency_m[frame, ...] = _neighbours_indices_in_frame(
-                positions[frame], num_neighbours, adjacency=True, mode=mode)
+                positions[frame], num_neighbours, adjacency=True, mode=mode
+            )
     return adjacency_m
 
 
 def interindividual_distances(positions):
-    return adjacency_matrix(positions, mode='distance')
+    return adjacency_matrix(positions, mode="distance")
 
 
 def restrict(data, indices, individual=None):
@@ -142,14 +153,17 @@ def restrict(data, indices, individual=None):
     if individual is None:
         output_data = np.empty(
             [total_time_steps, num_individuals, num_restricted, coordinates],
-            dtype=data.dtype)
+            dtype=data.dtype,
+        )
         for frame in range(total_time_steps):
             output_data[frame, ...] = data[frame, indices[frame, :], :]
     else:
-        output_data = np.empty([total_time_steps, num_restricted, coordinates],
-                               dtype=data.dtype)
+        output_data = np.empty(
+            [total_time_steps, num_restricted, coordinates], dtype=data.dtype
+        )
         for frame in range(total_time_steps):
-            output_data[frame, ...] = data[frame,
-                                           indices[frame, individual], :]
+            output_data[frame, ...] = data[
+                frame, indices[frame, individual], :
+            ]
 
     return output_data

--- a/trajectorytools/socialcontext/socialcontext.py
+++ b/trajectorytools/socialcontext/socialcontext.py
@@ -1,7 +1,7 @@
+import numpy as np
 import scipy.spatial
 import scipy.spatial.distance as spdist
 from sklearn.neighbors import NearestNeighbors
-import numpy as np
 
 
 def _in_convex_hull(positions):

--- a/trajectorytools/trajectories.py
+++ b/trajectorytools/trajectories.py
@@ -18,8 +18,7 @@ def calculate_center_of_mass(trajectories, params):
     :param params: Dictionary of parameters
     """
     center_of_mass = {
-        k: np.nanmean(trajectories[k], axis=1)
-        for k in Trajectory.keys_to_copy
+        k: np.nanmean(trajectories[k], axis=1) for k in Trajectory.keys_to_copy
     }
     return CenterMassTrajectory(center_of_mass, params)
 
@@ -45,13 +44,15 @@ def radius_and_center_from_traj_dict(locations, traj_dict):
     :param traj_dict:
     """
 
-    if 'setup_points' in traj_dict and 'border' in traj_dict['setup_points']:
+    if "setup_points" in traj_dict and "border" in traj_dict["setup_points"]:
         arena_center, arena_radius = estimate_center_and_radius(
-            traj_dict['setup_points']['border'])
-    elif 'arena_radius' in traj_dict:
+            traj_dict["setup_points"]["border"]
+        )
+    elif "arena_radius" in traj_dict:
         logging.warning(
-            'Using arena_radius (untested and probably not working)')
-        arena_radius = traj_dict['arena_radius']
+            "Using arena_radius (untested and probably not working)"
+        )
+        arena_radius = traj_dict["arena_radius"]
         arena_center = None
     else:
         arena_radius, arena_center = None, None
@@ -72,7 +73,7 @@ def radius_and_center_from_traj_dict(locations, traj_dict):
 
 
 class Trajectory:
-    keys_to_copy = ['_s', '_v', '_a']
+    keys_to_copy = ["_s", "_v", "_a"]
     own_params = True
 
     def __init__(self, trajectories, params):
@@ -89,17 +90,18 @@ class Trajectory:
     # i.e. they do not change class member parameters
 
     def point_from_px(self, point):
-        return (point +
-                self.params['displacement']) / self.params['length_unit']
+        return (point + self.params["displacement"]) / self.params[
+            "length_unit"
+        ]
 
     def point_to_px(self, point):
-        return point * self.params['length_unit'] - self.params['displacement']
+        return point * self.params["length_unit"] - self.params["displacement"]
 
     def vector_from_px(self, vector):
-        return vector / self.params['length_unit']
+        return vector / self.params["length_unit"]
 
     def vector_to_px(self, vector):
-        return vector * self.params['length_unit']
+        return vector * self.params["length_unit"]
 
     @property
     def number_of_frames(self):
@@ -111,11 +113,11 @@ class Trajectory:
 
     @property
     def v(self):
-        return self.vector_from_px(self._v) * self.params['time_unit']
+        return self.vector_from_px(self._v) * self.params["time_unit"]
 
     @property
     def a(self):
-        return self.vector_from_px(self._a) * (self.params['time_unit']**2)
+        return self.vector_from_px(self._a) * (self.params["time_unit"] ** 2)
 
     @property
     def speed(self):
@@ -165,20 +167,20 @@ class Trajectory:
     # Properties with side-effects
     # i.e. they change class member parameters
 
-    def new_length_unit(self, length_unit, length_unit_name='?'):
-        factor = self.params['length_unit'] / length_unit
+    def new_length_unit(self, length_unit, length_unit_name="?"):
+        factor = self.params["length_unit"] / length_unit
         if self.own_params:
-            if 'radius' in self.params:
-                self.params['radius'] = self.params['radius'] * factor
-            self.params['length_unit'] = length_unit
-            self.params['length_unit_name'] = length_unit_name
+            if "radius" in self.params:
+                self.params["radius"] = self.params["radius"] * factor
+            self.params["length_unit"] = length_unit
+            self.params["length_unit_name"] = length_unit_name
         return factor  # In the future it will return self
 
-    def new_time_unit(self, time_unit, time_unit_name='?'):
-        factor = self.params['time_unit'] / time_unit
+    def new_time_unit(self, time_unit, time_unit_name="?"):
+        factor = self.params["time_unit"] / time_unit
         if self.own_params:
-            self.params['time_unit'] = time_unit
-            self.params['time_unit_name'] = time_unit_name
+            self.params["time_unit"] = time_unit
+            self.params["time_unit_name"] = time_unit_name
         return factor  # In the future it will return self
 
     def origin_to(self, new_origin):
@@ -188,23 +190,23 @@ class Trajectory:
         It is expressed in the original frame of reference (usually px).
         """
         if self.own_params:
-            self.params['displacement'] = -new_origin
+            self.params["displacement"] = -new_origin
         return self
 
     def resample(self, new_frame_rate, **kwargs):
         # This function modifies _s, _v and _a
         # In the future it will not modify the current Trajectory
         # But it will produce a new one
-        if 'frame_rate' not in self.params:
+        if "frame_rate" not in self.params:
             raise Exception("Frame rate not in trajectories")
-        old_frame_rate = self.params['frame_rate']
+        old_frame_rate = self.params["frame_rate"]
         fraction = new_frame_rate / old_frame_rate
         self._s = tt.resample(self._s, new_frame_rate, old_frame_rate, kwargs)
         self._v = tt.resample(self._v, new_frame_rate, old_frame_rate, kwargs)
         self._a = tt.resample(self._a, new_frame_rate, old_frame_rate, kwargs)
         if self.own_params:
-            self.params['frame_rate'] = new_frame_rate
-            self.params['time_unit'] = self.params['time_unit'] * fraction
+            self.params["frame_rate"] = new_frame_rate
+            self.params["time_unit"] = self.params["time_unit"] * fraction
         return self
 
     # methods and properties wrt points
@@ -232,7 +234,8 @@ class Trajectory:
     @property
     def distance_to_center(self):
         raise Exception(
-            'Deprecated: Center trajectories with origin_to and use distance_to_origin')
+            "Deprecated: Center trajectories with origin_to and use distance_to_origin"
+        )
 
     @property
     def distance_to_origin(self):
@@ -246,14 +249,18 @@ class CenterMassTrajectory(Trajectory):
 class Trajectories(Trajectory):
     def __init__(self, trajectories, params):
         super().__init__(trajectories, params)
-        self.center_of_mass = calculate_center_of_mass(trajectories,
-                                                       self.params)
+        self.center_of_mass = calculate_center_of_mass(
+            trajectories, self.params
+        )
 
     def _dict_to_save(self):
         traj_data = {key: self.__dict__[key] for key in self.keys_to_copy}
         params = self.params
-        return {'traj_data': traj_data, 'params': params,
-                'class_name': self.__class__.__name__}
+        return {
+            "traj_data": traj_data,
+            "params": params,
+            "class_name": self.__class__.__name__,
+        }
 
     def save(self, filename):
         np.save(filename, self._dict_to_save())
@@ -261,19 +268,17 @@ class Trajectories(Trajectory):
     @classmethod
     def load(cls, filename):
         loaded_dict = np.load(filename, allow_pickle=True).item()
-        return cls(loaded_dict['traj_data'], loaded_dict['params'])
+        return cls(loaded_dict["traj_data"], loaded_dict["params"])
 
     def __getitem__(self, val):
         view_trajectories = {
-            k: getattr(self, k)[val]
-            for k in self.keys_to_copy
+            k: getattr(self, k)[val] for k in self.keys_to_copy
         }
         return self.__class__(view_trajectories, self.params)
 
     def restrict_individuals(self, val):
         view_trajectories = {
-            k: getattr(self, k)[:, val]
-            for k in self.keys_to_copy
+            k: getattr(self, k)[:, val] for k in self.keys_to_copy
         }
         return self.__class__(view_trajectories, self.params)
 
@@ -282,12 +287,15 @@ class Trajectories(Trajectory):
         return self[slice(start, end)]
 
     def __str__(self):
-        if 'path' in self.params:
+        if "path" in self.params:
             maybe_loaded = f"from {self.params['path']} "
         else:
-            maybe_loaded = ''
-        return f"<{self.__class__.__name__} " + maybe_loaded\
+            maybe_loaded = ""
+        return (
+            f"<{self.__class__.__name__} "
+            + maybe_loaded
             + f"-- frames:{self._s.shape[0]}, individuals:{self._s.shape[1]}>"
+        )
 
     @classmethod
     def from_idtrackerai(cls, trajectories_path, **kwargs):
@@ -299,20 +307,22 @@ class Trajectories(Trajectory):
 
         :param trajectories_path: idtracker.ai generated file
         """
-        traj_dict = np.load(trajectories_path,
-                            encoding='latin1',
-                            allow_pickle=True).item()
+        traj_dict = np.load(
+            trajectories_path, encoding="latin1", allow_pickle=True
+        ).item()
         tr = cls.from_idtracker_(traj_dict, **kwargs)
-        tr.params['path'] = trajectories_path
+        tr.params["path"] = trajectories_path
         return tr
 
     @classmethod
-    def from_idtracker_(cls,
-                        traj_dict,
-                        interpolate_nans=True,
-                        center=False,
-                        smooth_params=None,
-                        dtype=np.float64):
+    def from_idtracker_(
+        cls,
+        traj_dict,
+        interpolate_nans=True,
+        center=False,
+        smooth_params=None,
+        dtype=np.float64,
+    ):
         """Create Trajectories from a idtracker.ai trajectories dictionary
 
         :param traj_dict: idtracker.ai generated dictionary
@@ -323,19 +333,20 @@ class Trajectories(Trajectory):
         :param dtype: Desired dtype of trajectories.
         """
 
-        t = traj_dict['trajectories'].astype(dtype)
-        traj = cls.from_positions(t,
-                                  interpolate_nans=interpolate_nans,
-                                  smooth_params=smooth_params)
+        t = traj_dict["trajectories"].astype(dtype)
+        traj = cls.from_positions(
+            t, interpolate_nans=interpolate_nans, smooth_params=smooth_params
+        )
 
         radius, center_ = radius_and_center_from_traj_dict(traj._s, traj_dict)
         traj.params.update(
-            dict(radius=radius, radius_px=radius, _center=center_))
+            dict(radius=radius, radius_px=radius, _center=center_)
+        )
         if center:
-            traj.origin_to(traj.params['_center'])
+            traj.origin_to(traj.params["_center"])
 
-        traj.params['frame_rate'] = traj_dict.get('frames_per_second', None)
-        traj.params['body_length_px'] = traj_dict.get('body_length', None)
+        traj.params["frame_rate"] = traj_dict.get("frames_per_second", None)
+        traj.params["body_length_px"] = traj_dict.get("body_length", None)
         return traj
 
     @classmethod
@@ -347,7 +358,7 @@ class Trajectories(Trajectory):
         :param smooth_params: Arguments for smoothing (see tt.smooth)
         """
         if smooth_params is None:
-            smooth_params = {'sigma': -1, 'only_past': False}
+            smooth_params = {"sigma": -1, "only_past": False}
         # Interpolate trajectories
         if interpolate_nans:
             tt.interpolate_nans(t)
@@ -355,42 +366,50 @@ class Trajectories(Trajectory):
         displacement = np.array([0.0, 0.0])
 
         # Smooth trajectories
-        if smooth_params['sigma'] > 0:
+        if smooth_params["sigma"] > 0:
             t_smooth = tt.smooth(t, **smooth_params)
         else:
             t_smooth = t
 
         trajectories = {}
 
-        if smooth_params.get('only_past', False):
-            [trajectories['_s'], trajectories['_v'], trajectories['_a']] = \
-                tt.velocity_acceleration_backwards(t_smooth)
+        if smooth_params.get("only_past", False):
+            [
+                trajectories["_s"],
+                trajectories["_v"],
+                trajectories["_a"],
+            ] = tt.velocity_acceleration_backwards(t_smooth)
         else:
-            [trajectories['_s'], trajectories['_v'], trajectories['_a']] = \
-                tt.velocity_acceleration(t_smooth)
+            [
+                trajectories["_s"],
+                trajectories["_v"],
+                trajectories["_a"],
+            ] = tt.velocity_acceleration(t_smooth)
 
         params = {
             "displacement": displacement,  # Units: pixels
             "length_unit": 1,  # Units: pixels
-            "length_unit_name": 'px',
+            "length_unit_name": "px",
             "time_unit": 1,  # In frames
-            "time_unit_name": 'frames'
+            "time_unit_name": "frames",
         }
 
         return cls(trajectories, params)
 
     def normalise_by(self, normaliser):
         if not isinstance(normaliser, str):
-            raise Exception('normalise_by needs a string. To normalise by'
-                            'a number, please use new_length_unit')
-        if normaliser == 'body length' or normaliser == 'body_length':
-            length_unit = self.params['body_length_px']
-            length_unit_name = 'BL'
-        elif normaliser == 'radius':
-            length_unit = self.params['radius_px']
-            length_unit_name = 'R'
+            raise Exception(
+                "normalise_by needs a string. To normalise by"
+                "a number, please use new_length_unit"
+            )
+        if normaliser == "body length" or normaliser == "body_length":
+            length_unit = self.params["body_length_px"]
+            length_unit_name = "BL"
+        elif normaliser == "radius":
+            length_unit = self.params["radius_px"]
+            length_unit_name = "R"
         else:
-            raise Exception('Unknown key')
+            raise Exception("Unknown key")
         self.new_length_unit(length_unit, length_unit_name)
         return self
 
@@ -398,7 +417,7 @@ class Trajectories(Trajectory):
     def resample(self, *args, **kwargs):
         self.center_of_mass.resample(*args, **kwargs)
         super().resample(*args, **kwargs)
-    
+
     # Properties (without side effects)
 
     @property
@@ -407,8 +426,9 @@ class Trajectories(Trajectory):
 
     @property
     def mean_interindividual_distances(self):
-        return np.nansum(self.interindividual_distances,
-                         axis=-1) / (self.number_of_individuals - 1)
+        return np.nansum(self.interindividual_distances, axis=-1) / (
+            self.number_of_individuals - 1
+        )
 
     @property
     def number_of_individuals(self):
@@ -442,10 +462,12 @@ class FishTrajectories(Trajectories):
         all_bouts = []
         for focal in range(self.number_of_individuals):
             # Find local minima and maxima
-            min_frames_ = signal.find_peaks(-self.speed[:, focal],
-                                            **find_min_dict)[0]
-            max_frames_ = signal.find_peaks(self.speed[:, focal],
-                                            **find_max_dict)[0]
+            min_frames_ = signal.find_peaks(
+                -self.speed[:, focal], **find_min_dict
+            )[0]
+            max_frames_ = signal.find_peaks(
+                self.speed[:, focal], **find_max_dict
+            )[0]
 
             # Filter out NaNs
             min_frames = [
@@ -459,19 +481,22 @@ class FishTrajectories(Trajectories):
             frames = min_frames + max_frames
             frameismax = [False] * len(min_frames) + [True] * len(max_frames)
             ordered_frames, ordered_ismax = zip(
-                *sorted(zip(frames, frameismax)))
+                *sorted(zip(frames, frameismax))
+            )
             bouts = [
-                ordered_frames[i:i + 2]
+                ordered_frames[i : i + 2]
                 for i in range(len(ordered_frames) - 1)
                 if not ordered_ismax[i] and ordered_ismax[i + 1]
             ]
 
             # Ordering, and adding next_bout
             starting_bouts, bout_peaks = zip(*bouts)
-            next_bout_start = list(
-                starting_bouts[1:]) + [self.number_of_frames - 1]
+            next_bout_start = list(starting_bouts[1:]) + [
+                self.number_of_frames - 1
+            ]
             bouts = np.asarray(
-                list(zip(starting_bouts, bout_peaks, next_bout_start)))
+                list(zip(starting_bouts, bout_peaks, next_bout_start))
+            )
             all_bouts.append(bouts)
         return all_bouts
 
@@ -482,19 +507,22 @@ class TrajectoriesWithPoints(Trajectories):
         self._points = points if points is not None else {}
 
     def _dict_to_save(self):
-        update_dict = {'points': self.points}
+        update_dict = {"points": self.points}
         return {**super()._dict_to_save(), **update_dict}
 
     @classmethod
     def load(cls, filename):
         loaded_dict = np.load(filename, allow_pickle=True).item()
-        return cls(loaded_dict['traj_data'], loaded_dict['params'],
-                   points=loaded_dict['points'])
+        return cls(
+            loaded_dict["traj_data"],
+            loaded_dict["params"],
+            points=loaded_dict["points"],
+        )
 
     @classmethod
     def from_idtracker_(cls, traj_dict, **kwargs):
         twp = super().from_idtracker_(traj_dict, **kwargs)
-        twp._points = traj_dict['setup_points']
+        twp._points = traj_dict["setup_points"]
         return twp
 
     def __getitem__(self, val):

--- a/trajectorytools/trajectories.py
+++ b/trajectorytools/trajectories.py
@@ -1,10 +1,10 @@
+import logging
 from copy import deepcopy
 
 import numpy as np
 from scipy import signal
 
 import trajectorytools as tt
-import logging
 
 
 def calculate_center_of_mass(trajectories, params):


### PR DESCRIPTION
The reason to use an autoformatter is to not waste time deciding format: "By using Black, you agree to cede control over minutiae of hand-formatting. In return, Black gives you speed, determinism, and freedom from pycodestyle nagging about formatting. You will save time and mental energy for more important matters."

I spent some time researching, and black seems the best option. Nice defaults, fast, deterministic and few configuration options. It can be integrated with both pycharm and vim. It also has smileys.

https://black.readthedocs.io

I have used all defaults except for line length (using 79 ch per line PEP8 standard instead of 88 ch per line black default). All code was changed by using `black -l 79`. 

If you like this format, I propose:
- To use always use it in this project (mention this on the README)
- To add a check in CI to enforce all new code to have been formatted like this

The reason to change all the project at once is to make git blame more legible. We can also ignore single commits in git blame.

What black (nor any other formatter does):
- Break long lines in comments (need to be done manually)

NOTE: Some of black choices are compatible with PEP8 but flagged by pylint. At least the following need to be ignored in pylint:
- W503 line break before binary operator
- E203 whitespace before ':'
- C0330 Wrong hanging indentation before block