### PR TITLE
Merge from develop for 0.3.3

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -22,6 +22,7 @@ including the line length limit of 79 for python code and 72 for docs/comments.
 a uniform code look. Before submitting pull requests, we would appreciate if 
 you autoformat the code using the following command: `black -l 79 .`
 + Whenever possible, we create tests for any new code.
++ We are keeping a [CHANGELOG](../CHANGELOG.md)
 
 If you are like us some years ago and have problems following these rules,
 we are happy to help you implement them during the pull request process.

--- a/.github/workflows/pythonpackage_coverage.yml
+++ b/.github/workflows/pythonpackage_coverage.yml
@@ -35,8 +35,10 @@ jobs:
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors, deprecations or undefined names
-        # our line length is 79 (72 for docstrings), and we are strict (stop) if above 88
-        flake8 . --count --select=E5,E9,W6,F63,F7,F82 --max-line-length=88 --show-source --statistics
+        # our line length is 79 (72 for docstrings), and we are strict (stop) if above 87
+        # Goal: flake8 trajectorytools --extend-ignore=E203,W503,C0330
+        flake8 trajectorytools --max-line-length 87 --extend-ignore=E203,W503,F401,F403,E741 --show-source --statistics
+        #
         # exit-zero treats all errors as warnings.
         # ignoring when clashing with black:
         # - W503 line break before binary operator

--- a/.github/workflows/pythonpackage_older.yml
+++ b/.github/workflows/pythonpackage_older.yml
@@ -32,8 +32,6 @@ jobs:
       run: |
         # stop the build if there are Python syntax errors or undefined names
         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test
       run: |
         pytest tests/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 - Minor refactoring (`find_bouts_individual`)
 - Black version 20.8
 - updated README to warn about the two missing frames due to the computation of the velocity and acceleration.
+- [created CHANGELOG](https://github.com/fjhheras/trajectorytools/pull/33)
 
 ## [0.3.2] - 2020-07-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
+
+
+## [0.3.3] - Unreleased
+
+### Added
+
+- Now it is possible to export trajectories to csv
+
+### Removed
+
+- Deprecated unused code (`average_across_individuals`, `sum_across_individuals`)
+
+### Changed
+
+- Removing some deprecation warnings (`center_trajectories_and_obtain_radius`, `center_trajectories_and_normalise`) because an alternative is not available yet.
+- Adding deprecation warnings (`Trajectory.orientation_towards`)
+- Deprecation warning from `from_idtracker` (use `from_idtrackerai` instead)
+- Compute `arena_center` if does not exist in `radius_and_center_from_traj_dict`
+
+### Minor (less important or not affecting user)
+
+- Minor refactoring (`find_bouts_individual`)
+- Black version 20.8
+- updated README to warn about the two missing frames due to the computation of the velocity and acceleration.
+
+## [0.3.2] - 2020-07-11
+
+### Added
+
+- Added some utilities to perform polar plots to `plot/polar.py`
+
+### Changed
+
+- Changed function names in `social_context`, and made the per-frame versions public (`neighbour_indices_in_frame`, `adjacency_matrix_in_frame`)

--- a/README.rst
+++ b/README.rst
@@ -108,8 +108,8 @@ recorded in de Polavieja Lab (Champalimaud Research, Lisbon)
 .. _data: trajectorytools/data
 
 
-Authors
-==========
+Project maintainers
+===================
 
 Francisco J.H. Heras (2017-)
 Francisco Romero Ferrero (2017-)

--- a/README.rst
+++ b/README.rst
@@ -119,10 +119,11 @@ recorded in de Polavieja Lab (Champalimaud Research, Lisbon)
 ---
 **NOTE**
 
-Note that, due to the computation of velocities and accelerations the
-`traj` object has N-2 frames. By default the missing frames correspond
-to the first and last frames of the video. If you used passed the option
-`"only_past":True` in the `smooth_params`, the missing frames correspond
+Note that, when using constructors like `from_idtrackerai` and `from_positions`, 
+we need to calculate velocity and accelerations from positions. As a result, the
+`traj` object has 2 frames less than the original positions array. By default, the 
+missing frames correspond to the first and last frames of the video. If you used 
+the option `"only_past":True` in `smooth_params`, the missing frames correspond
 to the first two frames of the video.
 
 ---
@@ -152,5 +153,4 @@ If you use this work in an academic context and you want to acknowledge us, plea
 Romero-Ferrero, F., Bergomi, M. G., Hinz, R. C., Heras, F. J., & de Polavieja, G. G. (2019). idtracker.ai: tracking all individuals in small or large collectives of unmarked animals. Nature methods, 1
 
 Heras, F. J., Romero-Ferrero, F., Hinz, R. C., & de Polavieja, G. G. (2019). Deep attention networks reveal the rules of collective motion in zebrafish. PLoS computational biology, 15(9), e1007354.
-
 

--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,16 @@ or alternatively, locally with a symlink:
 .. code-block:: bash
     
     pip install -e .
-   
+
+If you see this error: "gcc: fatal error: cannot execute ‘cc1plus’: 
+execvp: No such file or directory" you need the GNU C++ compiler. 
+To install it in, for example, Ubuntu and derivatives:
+
+.. code-block:: bash
+    
+    sudo apt install g++
+
+
 Example
 ==========
 

--- a/README.rst
+++ b/README.rst
@@ -116,6 +116,16 @@ recorded in de Polavieja Lab (Champalimaud Research, Lisbon)
 .. _directory examples: trajectorytools/examples
 .. _data: trajectorytools/data
 
+---
+**NOTE**
+
+Note that, due to the computation of velocities and accelerations the
+`traj` object has N-2 frames. By default the missing frames correspond
+to the first and last frames of the video. If you used passed the option
+`"only_past":True` in the `smooth_params`, the missing frames correspond
+to the first two frames of the video.
+
+---
 
 Project maintainers
 ===================

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     description="A tool to study 2D trajectories",
     long_description=long_description,
     url="http://github.com/fjhheras/trajectorytools",
-    author="Francisco J.H. Heras, Francisco Romero Ferrero",
+    author="Francisco J.H. Heras, Francisco Romero Ferrero, Gonzalo G. de Polavieja",
     author_email="fjhheras@gmail.com",
     license="GPL",
     install_requires=["MiniballCpp", "matplotlib", "scikit-learn", "scipy"],

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.rst", "r") as fh:
 
 setup(
     name="trajectorytools",
-    version="0.3.2-alpha",
+    version="0.3.3-alpha",
     description="A tool to study 2D trajectories",
     long_description=long_description,
     url="http://github.com/fjhheras/trajectorytools",

--- a/tests/interpolate_test.py
+++ b/tests/interpolate_test.py
@@ -15,9 +15,9 @@ from trajectorytools.interpolate import (
 
 class TestCircle:
     def setup_class(self):
-        angles = np.random.rand(50, 10) * 2 * np.pi
-        self.center = np.random.randn(2)
-        self.R = 1 + np.random.rand(1)
+        angles = np.random.rand(2000, 10) * 2 * np.pi
+        self.center = 5 * np.random.randn(2)
+        self.R = 5 + 5 * np.random.rand(1)
         self.t = np.stack(
             [
                 self.R * np.cos(angles) + self.center[0],
@@ -33,9 +33,9 @@ class TestCircle:
     def test_consistency(self, func_find_circle):
         center_x, center_y, radius = func_find_circle(self.t)
         # It is possible but highly improbable that this test fails by chance
-        assert pytest.approx(center_x, 1e-2) == self.center[0]
-        assert pytest.approx(center_y, 1e-2) == self.center[1]
-        assert pytest.approx(radius, 1e-2) == self.R
+        assert pytest.approx(center_x, 1e-4) == self.center[0]
+        assert pytest.approx(center_y, 1e-4) == self.center[1]
+        assert pytest.approx(radius, 1e-4) == self.R
 
     @pytest.mark.parametrize(
         "func_find_circle",

--- a/tests/plot/test_polar.py
+++ b/tests/plot/test_polar.py
@@ -13,16 +13,16 @@ class TestPolar:
         self.args_hist = [self.r, self.theta]
 
     @pytest.mark.parametrize("entry", range(3))
-    @pytest.mark.xfail(raises=ValueError)
     def test_binned_statistic_value_error(self, entry):
         self.args[entry] = self.args[entry][:5]
-        binned_statistic_polar(*self.args)
+        with pytest.raises(ValueError):
+            binned_statistic_polar(*self.args)
 
     @pytest.mark.parametrize("entry", range(2))
-    @pytest.mark.xfail(raises=ValueError)
     def test_polar_histogram_value_error(self, entry):
         self.args_hist[entry] = self.args[entry][:5]
-        polar_histogram(*self.args_hist)
+        with pytest.raises(ValueError):
+            polar_histogram(*self.args_hist)
 
     def test_binned_statistic_expected(self):
         result = binned_statistic_polar(*self.args, bins=3, range_r=5)

--- a/tests/test_trajectories.py
+++ b/tests/test_trajectories.py
@@ -1,3 +1,4 @@
+import os
 import random
 import tempfile
 import unittest
@@ -85,6 +86,22 @@ class TrajectoriesTestCase(unittest.TestCase):
                 self.t.normal_acceleration ** 2 + self.t.tg_acceleration ** 2
             ),
         )
+
+    def test_export_csv(self):
+        # Create a temporary csv file
+        fhandle, fpath = tempfile.mkstemp(suffix=".csv")
+        os.close(fhandle)
+        self.t.export_trajectories_to_csv(fpath)
+
+        # Load and compare
+        t = np.loadtxt(fpath, skiprows=1, delimiter=",")
+        t = t.reshape(self.t.number_of_frames, self.t.number_of_individuals, 6)
+        np.testing.assert_almost_equal(t[..., :2], self.t.s)
+        np.testing.assert_almost_equal(t[..., 2:4], self.t.v)
+        np.testing.assert_almost_equal(t[..., 4:], self.t.a)
+
+        # Remove temporary csv file
+        os.remove(fpath)
 
 
 class TrajectoriesTestCaseUnitChange(TrajectoriesTestCase):

--- a/tests/test_trajectories.py
+++ b/tests/test_trajectories.py
@@ -98,6 +98,12 @@ class TrajectoriesNoInterpolateTestCase(unittest.TestCase):
         # Remove temporary csv file
         os.remove(fpath)
 
+    def test_angle_towards(self):
+        p = np.random.rand(2)
+        angle = self.t.angle_towards(p)
+        signed_angle = self.t.signed_angle_towards(p)
+        np.testing.assert_almost_equal(angle, np.abs(signed_angle))
+
 
 class TrajectoriesTestCase(TrajectoriesNoInterpolateTestCase):
     def setUp(self):

--- a/tests/test_trajectories.py
+++ b/tests/test_trajectories.py
@@ -272,12 +272,11 @@ class TrajectoriesWithPointsTestCase(TrajectoriesTestCase):
 
     def test_correct_class(self):
         assert isinstance(self.t, TrajectoriesWithPoints)
-    
-    def test_angle_towards(self):
-        angle = self.t.angle_towards_point('left_light')
-        signed_angle = self.t.signed_angle_towards_point('left_light')
-        np.testing.assert_almost_equal(angle, np.abs(signed_angle))
 
+    def test_angle_towards(self):
+        angle = self.t.angle_towards_point("left_light")
+        signed_angle = self.t.signed_angle_towards_point("left_light")
+        np.testing.assert_almost_equal(angle, np.abs(signed_angle))
 
 
 class TrajectoriesWithPointsTestCaseSaveLoad(TrajectoriesWithPointsTestCase):

--- a/tests/test_trajectories.py
+++ b/tests/test_trajectories.py
@@ -12,9 +12,11 @@ import trajectorytools.socialcontext as ttsocial
 from trajectorytools import Trajectories, TrajectoriesWithPoints
 
 
-class TrajectoriesTestCase(unittest.TestCase):
+class TrajectoriesNoInterpolateTestCase(unittest.TestCase):
     def setUp(self):
-        self.t = Trajectories.from_idtrackerai(cons.test_trajectories_path)
+        self.t = Trajectories.from_idtrackerai(
+            cons.test_trajectories_path, interpolate_nans=False
+        )
 
     def test_len(self):
         assert len(self.t) == self.t._a.shape[0]
@@ -72,13 +74,6 @@ class TrajectoriesTestCase(unittest.TestCase):
         nptest.assert_allclose(self.t.v, v / factor_length * factor_time)
         nptest.assert_allclose(self.t.a, a / factor_length * factor_time ** 2)
 
-    def test_straightness(self):
-        straight = self.t.straightness
-        assert np.all(straight <= 1)
-        assert np.all(straight >= 0)
-        assert straight.ndim == 1
-        assert straight.shape[0] == self.t.number_of_individuals
-
     def test_acceleration(self):
         nptest.assert_allclose(
             self.t.acceleration,
@@ -102,6 +97,18 @@ class TrajectoriesTestCase(unittest.TestCase):
 
         # Remove temporary csv file
         os.remove(fpath)
+
+
+class TrajectoriesTestCase(TrajectoriesNoInterpolateTestCase):
+    def setUp(self):
+        self.t = Trajectories.from_idtrackerai(cons.test_trajectories_path)
+
+    def test_straightness(self):
+        straight = self.t.straightness
+        assert np.all(straight <= 1)
+        assert np.all(straight >= 0)
+        assert straight.ndim == 1
+        assert straight.shape[0] == self.t.number_of_individuals
 
 
 class TrajectoriesTestCaseUnitChange(TrajectoriesTestCase):

--- a/tests/test_trajectories.py
+++ b/tests/test_trajectories.py
@@ -98,12 +98,6 @@ class TrajectoriesNoInterpolateTestCase(unittest.TestCase):
         # Remove temporary csv file
         os.remove(fpath)
 
-    def test_angle_towards(self):
-        p = np.random.rand(2)
-        angle = self.t.angle_towards(p)
-        signed_angle = self.t.signed_angle_towards(p)
-        np.testing.assert_almost_equal(angle, np.abs(signed_angle))
-
 
 class TrajectoriesTestCase(TrajectoriesNoInterpolateTestCase):
     def setUp(self):
@@ -278,6 +272,12 @@ class TrajectoriesWithPointsTestCase(TrajectoriesTestCase):
 
     def test_correct_class(self):
         assert isinstance(self.t, TrajectoriesWithPoints)
+    
+    def test_angle_towards(self):
+        angle = self.t.angle_towards_point('left_light')
+        signed_angle = self.t.signed_angle_towards_point('left_light')
+        np.testing.assert_almost_equal(angle, np.abs(signed_angle))
+
 
 
 class TrajectoriesWithPointsTestCaseSaveLoad(TrajectoriesWithPointsTestCase):

--- a/tests/test_trajectories.py
+++ b/tests/test_trajectories.py
@@ -595,10 +595,10 @@ class DownUpResample(DoubleTrajectoriesTestCase):
 
 class ScaleRadiusTrajectoriesTestCase(TrajectoriesTestCase):
     def setUp(self):
-        self.t = Trajectories.from_idtracker(
+        self.t = Trajectories.from_idtrackerai(
             cons.test_trajectories_path, center=True
         ).normalise_by("radius")
-        self.t_normal = Trajectories.from_idtracker(
+        self.t_normal = Trajectories.from_idtrackerai(
             cons.test_trajectories_path
         )
 
@@ -628,10 +628,10 @@ class ScaleRadiusTrajectoriesTestCase(TrajectoriesTestCase):
 
 class TrajectoriesRadiusTestCase(TrajectoriesTestCase):
     def setUp(self):
-        self.t_normal = Trajectories.from_idtracker(
+        self.t_normal = Trajectories.from_idtrackerai(
             cons.test_trajectories_path, smooth_params={"sigma": 1}
         )
-        self.t = Trajectories.from_idtracker(
+        self.t = Trajectories.from_idtrackerai(
             cons.test_trajectories_path, smooth_params={"sigma": 1}
         ).normalise_by("radius")
 

--- a/tests/test_trajectories.py
+++ b/tests/test_trajectories.py
@@ -1,3 +1,4 @@
+import random
 import tempfile
 import unittest
 
@@ -613,6 +614,33 @@ class TrajectoriesRadiusTestCase(TrajectoriesTestCase):
         nptest.assert_allclose(
             self.t.a, self.t_normal.a / self.t.params["radius_px"], atol=1e-15
         )
+
+
+class FishTrajectoriesTestCase(TrajectoriesTestCase):
+    def setUp(self):
+        self.t = tt.FishTrajectories.from_idtrackerai(
+            cons.test_trajectories_path
+        )
+
+    def test_simple(self):
+        find_dict = {"prominence": (0.01, None), "distance": 6}
+        all_bouts = self.t.get_bouts(
+            find_min_dict=find_dict, find_max_dict=find_dict
+        )
+        assert len(all_bouts) == self.t.number_of_individuals
+
+        # Choosing one individual at random for test
+        i = random.randrange(self.t.number_of_individuals)
+        bouts = all_bouts[i]
+        speed = self.t.speed[:, i]
+
+        # Last frame of one bout is the first of the next
+        np.testing.assert_almost_equal(bouts[:-1, 2], bouts[1:, 0])
+
+        # Faster in the peak than start/end
+        for b in bouts:
+            assert speed[b[1]] >= speed[b[0]]
+            assert speed[b[1]] >= speed[b[2]]
 
 
 if __name__ == "__main__":

--- a/tests/test_trajectories2.py
+++ b/tests/test_trajectories2.py
@@ -1,0 +1,71 @@
+import pytest
+import numpy as np
+from trajectorytools.trajectories import radius_and_center_from_traj_dict
+
+
+def circular_trajectory(radius=1, center=(0, 0)):
+    length = 100
+    max_rad = 5  # Almost a complete circle
+    omega = max_rad / length
+    # Calculation
+    offset = max_rad * np.random.rand()
+    angles = np.arange(length) * omega + offset
+    return np.stack(
+        [
+            radius * np.sin(angles) + center[0],
+            radius * np.cos(angles) + center[1],
+        ],
+        axis=-1,
+    )
+
+
+def circular_trajectories(number_of_individuals, radius=1, center=(0, 0)):
+    return np.stack(
+        [
+            circular_trajectory(radius=radius, center=center)
+            for _ in range(number_of_individuals)
+        ]
+    )
+
+
+def traj_dict(border=None, arena_radius=None, arena_center=None):
+    if border is not None:
+        d = dict(setup_points=dict(border=border))
+    else:
+        d = {}
+    if arena_radius is not None:
+        d["arena_radius"] = arena_radius
+    if arena_center is not None:
+        d["arena_center"] = arena_center
+    return d
+
+
+param_list = [
+    (
+        circular_trajectories(3, radius=0.5),
+        traj_dict(border=circular_trajectory()),
+        dict(radius=1, center_a=(0, 0)),
+    ),
+    (
+        circular_trajectories(3, radius=0.5),
+        {},
+        dict(radius=0.5, center_a=(0, 0)),
+    ),
+    (
+        circular_trajectories(3, radius=0.5, center=(0.1, 0.2)),
+        traj_dict(arena_radius=1),
+        dict(radius=1, center_a=(0.1, 0.2)),
+    ),
+    (
+        circular_trajectories(3, radius=0.5, center=(0.1, 0.2)),
+        traj_dict(arena_center=(0.0, -0.1)),
+        dict(radius=0.5, center_a=(0.0, -0.1)),
+    ),
+]
+
+
+@pytest.mark.parametrize("locations,traj_dict,expected", param_list)
+def test_radius_and_center_from_traj_dict(locations, traj_dict, expected):
+    radius, center_a = radius_and_center_from_traj_dict(locations, traj_dict)
+    np.testing.assert_allclose(radius, expected["radius"], atol=1e-15)
+    np.testing.assert_allclose(center_a, expected["center_a"], atol=1e-15)

--- a/tests/test_trajectories2.py
+++ b/tests/test_trajectories2.py
@@ -54,7 +54,12 @@ param_list = [
         {},
         dict(radius=0.5, center_a=(0, 0)),
     ),
-    # If partial info: use it and get the rest from traj
+    # Partial info: use it and get the rest from traj
+    (
+        circular_trajectories(6, radius=0.5, center=(0.1, 0.2)),
+        traj_dict(arena_radius=2, arena_center=(0.1, 0.1)),
+        dict(radius=2, center_a=(0.1, 0.1)),
+    ),
     (
         circular_trajectories(6, radius=0.5, center=(0.1, 0.2)),
         traj_dict(arena_radius=1),

--- a/tests/test_trajectories2.py
+++ b/tests/test_trajectories2.py
@@ -1,5 +1,6 @@
-import pytest
 import numpy as np
+import pytest
+
 from trajectorytools.trajectories import radius_and_center_from_traj_dict
 
 
@@ -41,23 +42,26 @@ def traj_dict(border=None, arena_radius=None, arena_center=None):
 
 
 param_list = [
+    # If border: use it
     (
-        circular_trajectories(3, radius=0.5),
+        circular_trajectories(6, radius=0.5),
         traj_dict(border=circular_trajectory()),
         dict(radius=1, center_a=(0, 0)),
     ),
+    # No info: get from tajectories
     (
-        circular_trajectories(3, radius=0.5),
+        circular_trajectories(6, radius=0.5),
         {},
         dict(radius=0.5, center_a=(0, 0)),
     ),
+    # If partial info: use it and get the rest from traj
     (
-        circular_trajectories(3, radius=0.5, center=(0.1, 0.2)),
+        circular_trajectories(6, radius=0.5, center=(0.1, 0.2)),
         traj_dict(arena_radius=1),
         dict(radius=1, center_a=(0.1, 0.2)),
     ),
     (
-        circular_trajectories(3, radius=0.5, center=(0.1, 0.2)),
+        circular_trajectories(6, radius=0.5, center=(0.1, 0.2)),
         traj_dict(arena_center=(0.0, -0.1)),
         dict(radius=0.5, center_a=(0.0, -0.1)),
     ),
@@ -67,5 +71,9 @@ param_list = [
 @pytest.mark.parametrize("locations,traj_dict,expected", param_list)
 def test_radius_and_center_from_traj_dict(locations, traj_dict, expected):
     radius, center_a = radius_and_center_from_traj_dict(locations, traj_dict)
-    np.testing.assert_allclose(radius, expected["radius"], atol=1e-15)
-    np.testing.assert_allclose(center_a, expected["center_a"], atol=1e-15)
+    np.testing.assert_allclose(
+        radius, expected["radius"], atol=1e-3, rtol=1e-3
+    )
+    np.testing.assert_allclose(
+        center_a, expected["center_a"], atol=1e-3, rtol=1e-3
+    )

--- a/trajectorytools/collective.py
+++ b/trajectorytools/collective.py
@@ -5,20 +5,6 @@ import numpy as np
 import trajectorytools as tt
 
 
-def average_across_individuals(s):
-    """ Averages along the penultimate dimension
-    """
-    warnings.warn(Warning("To be deprecated"))
-    return np.mean(s, axis=-2)
-
-
-def sum_across_individuals(s):
-    """ Sums along the penultimate dimension
-    """
-    warnings.warn(Warning("To be deprecated"))
-    return np.sum(s, axis=-2)
-
-
 def polarization(v):
     """ Calculates (the normalised) polarization vector
 

--- a/trajectorytools/collective.py
+++ b/trajectorytools/collective.py
@@ -6,9 +6,9 @@ import trajectorytools as tt
 
 
 def polarization(v):
-    """ Calculates (the normalised) polarization vector
+    """Calculates (the normalised) polarization vector
 
-    Reduction is performed on the penultimate dimension, which 
+    Reduction is performed on the penultimate dimension, which
     for normal trajectories (3 dims) means individuals, so a
     single polarisation is calculated per frame.
 
@@ -20,9 +20,9 @@ def polarization(v):
 
 
 def angular_momentum(v, s, center=np.array([0, 0])):
-    """ Calculates angular momentum around a point
+    """Calculates angular momentum around a point
 
-    Reduction is performed on the penultimate dimension, which 
+    Reduction is performed on the penultimate dimension, which
     for normal trajectories (3 dims) means individuals, so a
     single angular momentum is calculated per frame.
 

--- a/trajectorytools/examples/animate.py
+++ b/trajectorytools/examples/animate.py
@@ -5,8 +5,6 @@ import numpy as np
 
 import trajectorytools as tt
 import trajectorytools.animation as ttanimation
-import trajectorytools.plot as ttplot
-import trajectorytools.socialcontext as ttsocial
 from trajectorytools.constants import dir_of_data
 
 if __name__ == "__main__":
@@ -14,7 +12,10 @@ if __name__ == "__main__":
     t = np.load(test_trajectories_file)
     tt.center_trajectories_and_normalise(t)
     tt.interpolate_nans(t)
-    [s_, v_] = tt.smooth_several(t, derivatives=[0, 1])
+
+    t = tt.smooth(t, sigma=0.5)
+    s_, v_, a_ = tt.velocity_acceleration(t)
+
     speed = tt.norm(v_)
     colornorm = mpl.colors.Normalize(
         vmin=speed.min(), vmax=speed.max(), clip=True

--- a/trajectorytools/examples/example.py
+++ b/trajectorytools/examples/example.py
@@ -12,7 +12,8 @@ if __name__ == "__main__":
     test_trajectories_file = os.path.join(dir_of_data, "test_trajectories.npy")
     t = np.load(test_trajectories_file, allow_pickle=True)
     tt.interpolate_nans(t)
-    [s_, v_, a_] = tt.smooth_several(t, derivatives=[0, 1, 2])
+    t = tt.smooth(t, sigma=0.5)
+    s_, v_, a_ = tt.velocity_acceleration(t)
 
     n = t.shape[1]
     print("Number of fish: ", n)

--- a/trajectorytools/fish_bouts/fish_bouts.py
+++ b/trajectorytools/fish_bouts/fish_bouts.py
@@ -1,4 +1,56 @@
 import trajectorytools as tt
+import numpy as np
+import scipy.signal
+from typing import Any, Dict
+
+
+def find_bouts_individual(
+    speed: np.ndarray,
+    find_min_dict: Dict[str, Any] = None,
+    find_max_dict: Dict[str, Any] = None,
+) -> np.ndarray:
+    """Obtain frames of bouts fron the speed of one individual
+        
+        :param speed: array of shape (num frames, )
+        :param find_max_dict: kwargs for scipy.signal.find_peaks
+        :param find_min_dict: kwargs for scipy.signal.find_peaks
+
+        returns
+        :all_bouts: Array of shape (number_of_bouts, 3). Col-1 is the
+                    starting frame of the bout, col-2 is the frame 
+                    where the bout peaks, col-3 is the beginning of
+                    the next bout
+        """
+
+    if find_max_dict is None:
+        find_max_dict = {}
+    if find_min_dict is None:
+        find_min_dict = {}
+
+    number_of_frames = speed.shape[0]
+
+    # Find local minima and maxima
+    min_frames_ = scipy.signal.find_peaks(-speed, **find_min_dict)[0]
+    max_frames_ = scipy.signal.find_peaks(speed, **find_max_dict)[0]
+
+    # Filter out NaNs
+    min_frames = [f for f in min_frames_ if not np.isnan(speed[f])]
+    max_frames = [f for f in max_frames_ if not np.isnan(speed[f])]
+
+    # Obtain couples of consecutive minima and maxima
+    frames = min_frames + max_frames
+    frameismax = [False] * len(min_frames) + [True] * len(max_frames)
+    ordered_frames, ordered_ismax = zip(*sorted(zip(frames, frameismax)))
+    bouts = [
+        ordered_frames[i : i + 2]
+        for i in range(len(ordered_frames) - 1)
+        if not ordered_ismax[i] and ordered_ismax[i + 1]
+    ]
+
+    # Ordering, and adding next_bout
+    starting_bouts, bout_peaks = zip(*bouts)
+    next_bout_start = list(starting_bouts[1:]) + [number_of_frames - 1]
+    return np.array(list(zip(starting_bouts, bout_peaks, next_bout_start)))
 
 
 def bout_statistics():

--- a/trajectorytools/fish_bouts/fish_bouts.py
+++ b/trajectorytools/fish_bouts/fish_bouts.py
@@ -10,17 +10,17 @@ def find_bouts_individual(
     find_max_dict: Dict[str, Any] = None,
 ) -> np.ndarray:
     """Obtain frames of bouts from the speed of one individual
-        
-        :param speed: array of shape (num frames, )
-        :param find_max_dict: kwargs for scipy.signal.find_peaks
-        :param find_min_dict: kwargs for scipy.signal.find_peaks
 
-        returns
-        :all_bouts: Array of shape (number_of_bouts, 3). Col-1 is the
-                    starting frame of the bout, col-2 is the frame 
-                    where the bout peaks, col-3 is the beginning of
-                    the next bout
-        """
+    :param speed: array of shape (num frames, )
+    :param find_max_dict: kwargs for scipy.signal.find_peaks
+    :param find_min_dict: kwargs for scipy.signal.find_peaks
+
+    returns
+    :all_bouts: Array of shape (number_of_bouts, 3). Col-1 is the
+                starting frame of the bout, col-2 is the frame
+                where the bout peaks, col-3 is the beginning of
+                the next bout
+    """
 
     if find_max_dict is None:
         find_max_dict = {}

--- a/trajectorytools/fish_bouts/fish_bouts.py
+++ b/trajectorytools/fish_bouts/fish_bouts.py
@@ -9,7 +9,7 @@ def find_bouts_individual(
     find_min_dict: Dict[str, Any] = None,
     find_max_dict: Dict[str, Any] = None,
 ) -> np.ndarray:
-    """Obtain frames of bouts fron the speed of one individual
+    """Obtain frames of bouts from the speed of one individual
         
         :param speed: array of shape (num frames, )
         :param find_max_dict: kwargs for scipy.signal.find_peaks

--- a/trajectorytools/geometry.py
+++ b/trajectorytools/geometry.py
@@ -103,8 +103,7 @@ def center_in_individual(data, individual):
 
 
 def angle_between_vectors(x, y):
-    """Angle between vectors, between 0 and pi radians, no sign
-    """
+    """Angle between vectors, between 0 and pi radians, no sign"""
     u, v = normalise(x), normalise(y)
     return np.arccos(np.clip(dot(u, v), -1.0, +1.0))
 

--- a/trajectorytools/interpolate.py
+++ b/trajectorytools/interpolate.py
@@ -125,7 +125,7 @@ def find_enclosing_circle(t):
 
 
 def center_trajectories_and_obtain_radius(t, forced_radius=None):
-    warnings.warn(Warning("To be deprecated"))
+    # Soon to be changed by a simpler alternative
     center_x, center_y, radius = find_enclosing_circle(t)
     radius = radius if forced_radius is None else forced_radius
     t[..., 0] -= center_x
@@ -134,7 +134,7 @@ def center_trajectories_and_obtain_radius(t, forced_radius=None):
 
 
 def center_trajectories_and_normalise(t, unit_length=None, forced_radius=None):
-    warnings.warn(Warning("To be deprecated"))
+    # Soon to be changed by a simpler alternative
     center_x, center_y, radius = center_trajectories_and_obtain_radius(
         t, forced_radius=forced_radius
     )

--- a/trajectorytools/plot/plot.py
+++ b/trajectorytools/plot/plot.py
@@ -170,7 +170,7 @@ class Scene:
         )
 
 
-### Histogram / diagram stuff below
+# Histogram / diagram stuff below
 
 
 def get_spaced_colors(n, cmap="jet"):

--- a/trajectorytools/plot/polar.py
+++ b/trajectorytools/plot/polar.py
@@ -195,7 +195,7 @@ def plot_polar_histogram(
     fig = ax.get_figure()
     im = ax.pcolormesh(theta, r, values, cmap=cmap, vmin=vmin, vmax=vmax)
     cb = fig.colorbar(im, ax=ax, cmap=cmap)
-    cb.ax.tick_params(labelsize=24)
+    # cb.ax.tick_params(labelsize=24)
 
     if angle_convention == "clock":
         # Adjusting axis and sense of rotation to make it compatible

--- a/trajectorytools/plot/polar.py
+++ b/trajectorytools/plot/polar.py
@@ -10,8 +10,7 @@ __all__ = ["binned_statistic_polar", "polar_histogram", "plot_polar_histogram"]
 
 
 def remove_not_finite_from_args(f_unwrapped: Callable) -> Callable:
-    """ Decorator that removes nans from input numpy arrays
-    """
+    """Decorator that removes nans from input numpy arrays"""
 
     def wrapped(*args, **kwargs):
         for arg in args:
@@ -86,14 +85,14 @@ def polar_histogram(
     range_r: Union[Tuple[float, float], float] = 5,
     density: bool = False,
 ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """ Version of np.histogram2d for polar plots
+    """Version of np.histogram2d for polar plots
     :param r: 1d np.array
     :param theta: 1d np.array
     :param range_r: The leftmost and rightmost edges for radious bins.
     Leftmost and rightmost edges of theta are always -pi and pi
     :param bins: The bin specification.
-    :param density: If False, the default, returns the number of 
-    samples in each bin. If True, returns the probability density 
+    :param density: If False, the default, returns the number of
+    samples in each bin. If True, returns the probability density
     function at the bin: `bin_count / sample_count / bin_area`
     """
 
@@ -103,7 +102,11 @@ def polar_histogram(
     num_samples = len(r)
 
     H, r_edges, theta_edges = np.histogram2d(
-        r, theta, bins=bins, range=[range_r, [-np.pi, np.pi]], density=False,
+        r,
+        theta,
+        bins=bins,
+        range=[range_r, [-np.pi, np.pi]],
+        density=False,
     )
 
     if density:
@@ -148,11 +151,11 @@ def plot_polar_histogram(
     interpolation_factor: float = 5,
     angle_convention: str = "clock",
 ):
-    """ Plot color polar plot
+    """Plot color polar plot
 
-    :param values: Values to color-code 
-    :param r_edges: Edges in radius 
-    :param theta_edges: Edges in angle 
+    :param values: Values to color-code
+    :param r_edges: Edges in radius
+    :param theta_edges: Edges in angle
     :param ax: matplotlib.axes.Axes. Needs to be `polar=True`
     :param cmap: matplotlib colormap
     :param vmin: lower limit of colorbar range. If None, from data

--- a/trajectorytools/plot/polar.py
+++ b/trajectorytools/plot/polar.py
@@ -119,7 +119,7 @@ def polar_histogram(
     return H, r_edges, theta_edges
 
 
-## Plotting functions
+# Plotting functions
 
 
 def interpolate_polarmap_angles(
@@ -194,8 +194,7 @@ def plot_polar_histogram(
     # Plot histogram/map
     fig = ax.get_figure()
     im = ax.pcolormesh(theta, r, values, cmap=cmap, vmin=vmin, vmax=vmax)
-    cb = fig.colorbar(im, ax=ax, cmap=cmap)
-    # cb.ax.tick_params(labelsize=24)
+    fig.colorbar(im, ax=ax, cmap=cmap)
 
     if angle_convention == "clock":
         # Adjusting axis and sense of rotation to make it compatible

--- a/trajectorytools/socialcontext/leadership.py
+++ b/trajectorytools/socialcontext/leadership.py
@@ -10,7 +10,7 @@ def restrict_with_delay(data, indices, individual=None, delay=0):
 
     :param data: np.array with dimensions time x individuals x coordinates
     :param indices: np.array with dimensions time x individuals x subset_of_individuals
-    :param individual: label of individual to calculate restriction 
+    :param individual: label of individual to calculate restriction
     with delay. If None, calculating for all individuals
     :param delay:
 
@@ -29,7 +29,7 @@ def restrict_with_delay(data, indices, individual=None, delay=0):
 
 
 def sweep_delays(data, indices, max_delay, individual=None):
-    """ This function sweeps delays of whole data
+    """This function sweeps delays of whole data
     and outputs an array with an extra dimension
     """
     num_restricted = indices.shape[-1]
@@ -83,11 +83,11 @@ def dot_product_per_frame_with_delays(
 ):
     """
 
-    :param data: array of orientations 
+    :param data: array of orientations
     (total_frames, num_individuals, 2)
-    :param indices: indices of neighbours 
+    :param indices: indices of neighbours
     (total_frames, num_individuals, num_individuals-1)
-    :param sweeped_delays: arrays of sweeped orientations with lag 
+    :param sweeped_delays: arrays of sweeped orientations with lag
     (num_delays, total_frames-num_delays, num_individuals, num_individuals-1, 2)
     :param frame: frame to compute
     :param inplace: (num_delays, num_individuals, num_individual)
@@ -134,7 +134,7 @@ def sliding_average_dot_product_with_delays(
     (total_frames, num_individuals, 2)
     :param indices: indices of neighbours with shape
     (total_frames, num_individuals, num_individuals-1)
-    :param sweep_delayed_e: arrays of sweeped orientations with lag 
+    :param sweep_delayed_e: arrays of sweeped orientations with lag
     (num_delays, total_frames-num_delays, num_individuals, num_individuals-1, 2)
     :param start_frame: 0
     :param end_frame:

--- a/trajectorytools/socialcontext/socialcontext.py
+++ b/trajectorytools/socialcontext/socialcontext.py
@@ -75,9 +75,10 @@ def in_alpha_border(positions, alpha=5):
 
 
 def neighbour_indices_in_frame(
-    positions: np.ndarray, num_neighbours: int,
+    positions: np.ndarray,
+    num_neighbours: int,
 ) -> np.ndarray:
-    """ Calculate the indices of the nearest neighbours
+    """Calculate the indices of the nearest neighbours
 
     :param positions: array of locations with dimensions
     (individual x coordinates)
@@ -100,7 +101,7 @@ def give_indices(positions, num_neighbours):
 def neighbour_indices(
     positions: np.ndarray, num_neighbours: int
 ) -> np.ndarray:
-    """ Calculates the indices of the nearest neighbours
+    """Calculates the indices of the nearest neighbours
 
     :param positions: array of locations with dimensions
     (time x individual x coordinates)
@@ -121,13 +122,15 @@ def neighbour_indices(
 
 
 def adjacency_matrix_in_frame(
-    positions: np.ndarray, num_neighbours: int, mode: str = "connectivity",
+    positions: np.ndarray,
+    num_neighbours: int,
+    mode: str = "connectivity",
 ) -> np.ndarray:
     """
     :param positions: array of locations with dimensions
     (individual x coordinates)
     :param num_neighbours: number of closest neighbours requested
-    :param mode: adjacency mode "connectivity" or "distance".     
+    :param mode: adjacency mode "connectivity" or "distance".
     :return: output has dimension (individual x individual)
     """
     nbrs = NearestNeighbors(
@@ -181,9 +184,9 @@ def restrict(data, indices, individual=None):
     """restrict_with_delay
 
     :param data: np.array with shape time x individuals x coordinates
-    :param indices: np.array with shape 
+    :param indices: np.array with shape
     time x individuals x subset_of_individuals
-    :param individual: label of individual to calculate restriction 
+    :param individual: label of individual to calculate restriction
     with delay. If None, calculating for all individuals
     """
     num_restricted = indices.shape[-1]

--- a/trajectorytools/trajectories.py
+++ b/trajectorytools/trajectories.py
@@ -224,6 +224,9 @@ class Trajectory:
     def angle_towards(self, point):
         return np.arccos(np.clip(self.e_towards(point), -1, 1))
 
+    def signed_angle_towards(self, point):
+        return tt.signed_angle_between_vectors(point - self.s, self.v)
+
     def e_towards(self, point):
         return self._projection_vector_towards(point, self.e)
 
@@ -530,6 +533,9 @@ class TrajectoriesWithPoints(Trajectories):
 
     def angle_towards_point(self, key):
         return self.angle_towards(self.points[key])
+
+    def signed_angle_towards_point(self, key):
+        return self.signed_angle_towards(self.points[key])
 
     def e_towards_point(self, key):
         return self.e_towards(self.points[key])

--- a/trajectorytools/trajectories.py
+++ b/trajectorytools/trajectories.py
@@ -322,7 +322,9 @@ class Trajectories(Trajectory):
 
     @classmethod
     def from_idtrackerai(cls, trajectories_path, **kwargs):
-        return cls.from_idtracker(trajectories_path, **kwargs)
+        tr = cls.from_idtracker(trajectories_path, **kwargs)
+        tr.params["construct_method"] = "from_idtrackerai"
+        return tr
 
     @classmethod
     def from_idtracker(cls, trajectories_path, **kwargs):
@@ -335,6 +337,7 @@ class Trajectories(Trajectory):
         ).item()
         tr = cls.from_idtracker_(traj_dict, **kwargs)
         tr.params["path"] = trajectories_path
+        tr.params["construct_method"] = "from_idtracker"
         return tr
 
     @classmethod
@@ -370,6 +373,7 @@ class Trajectories(Trajectory):
 
         traj.params["frame_rate"] = traj_dict.get("frames_per_second", None)
         traj.params["body_length_px"] = traj_dict.get("body_length", None)
+        traj.params["construct_method"] = "from_idtracker_"
         return traj
 
     @classmethod
@@ -409,12 +413,19 @@ class Trajectories(Trajectory):
                 trajectories["_a"],
             ] = tt.velocity_acceleration(t_smooth)
 
+        # TODO: Think to give a hierarchy to the params dictionary
+        # Maybe in the future add a "how_construct" key being a dictionary
+        # with the classmethod called, path, interpolate_nans,
+        # and smooth_params
         params = {
             "displacement": displacement,  # Units: pixels
             "length_unit": 1,  # Units: pixels
             "length_unit_name": "px",
             "time_unit": 1,  # In frames
             "time_unit_name": "frames",
+            "interpolate_nans": interpolate_nans,
+            "smooth_params": smooth_params,
+            "construct_method": "from_positions",
         }
 
         return cls(trajectories, params)

--- a/trajectorytools/trajectories.py
+++ b/trajectorytools/trajectories.py
@@ -528,6 +528,9 @@ class TrajectoriesWithPoints(Trajectories):
     def orientation_towards_point(self, key):
         return self.orientation_towards(self.points[key])
 
+    def angle_towards_point(self, key):
+        return self.angle_towards(self.points[key])
+
     def e_towards_point(self, key):
         return self.e_towards(self.points[key])
 

--- a/trajectorytools/trajectories.py
+++ b/trajectorytools/trajectories.py
@@ -1,4 +1,5 @@
 import logging
+import warnings
 from copy import deepcopy
 
 import numpy as np

--- a/trajectorytools/trajectories.py
+++ b/trajectorytools/trajectories.py
@@ -44,31 +44,29 @@ def radius_and_center_from_traj_dict(locations, traj_dict):
     :param locations: Numpy array of locations. Last dim must be (x, y)
     :param traj_dict:
     """
-
     if "setup_points" in traj_dict and "border" in traj_dict["setup_points"]:
-        arena_center, arena_radius = estimate_center_and_radius(
+        center_a, radius = estimate_center_and_radius(
             traj_dict["setup_points"]["border"]
         )
-    elif "arena_radius" in traj_dict:
-        logging.warning(
-            "Using arena_radius (untested and probably not working)"
-        )
-        arena_radius = traj_dict["arena_radius"]
-        arena_center = None
     else:
-        arena_radius, arena_center = None, None
+        arena_radius = traj_dict.get("arena_radius", None)
+        arena_center = traj_dict.get("arena_center", None)
 
-    # Find center and radius. Then override if necessary
-    if arena_radius is None and arena_center is None:
-        center_a, estimated_radius = estimate_center_and_radius(locations)
+        # Find center and radius. Then override if necessary
+        if arena_radius is None or arena_center is None:
+            estimated_center, estimated_radius = estimate_center_and_radius(
+                locations
+            )
 
-    if arena_radius is None:
-        radius = estimated_radius
-    else:
-        radius = arena_radius
+        if arena_radius is None:
+            radius = estimated_radius
+        else:
+            radius = arena_radius
 
-    if arena_center is not None:
-        center_a = arena_center
+        if arena_center is None:
+            center_a = estimated_center
+        else:
+            center_a = arena_center
 
     return radius, center_a
 

--- a/trajectorytools/trajectories.py
+++ b/trajectorytools/trajectories.py
@@ -413,7 +413,7 @@ class Trajectories(Trajectory):
                 trajectories["_a"],
             ] = tt.velocity_acceleration(t_smooth)
 
-        # TODO: Think to give a hierarchy to the params dictionary
+        # TODO: Organise the params dictionary more hierarchically
         # Maybe in the future add a "how_construct" key being a dictionary
         # with the classmethod called, path, interpolate_nans,
         # and smooth_params

--- a/trajectorytools/trajectories.py
+++ b/trajectorytools/trajectories.py
@@ -216,7 +216,8 @@ class Trajectory:
     def _projection_vector_towards(self, point, vector):
         return tt.dot(tt.normalise(point - self.s), vector)
 
-    def orientation_towards(self, point):  # Soon to be deprecated
+    def orientation_towards(self, point):
+        warnings.warn(Warning("Deprecated. Use angle_towards instead"))
         return self.angle_towards(point)
 
     def angle_towards(self, point):
@@ -281,10 +282,6 @@ class Trajectories(Trajectory):
             k: getattr(self, k)[:, val] for k in self.keys_to_copy
         }
         return self.__class__(view_trajectories, self.params)
-
-    def view(self, start=None, end=None):
-        logging.warning("To be deprecated: use standard slicing instead")
-        return self[slice(start, end)]
 
     def __str__(self):
         if "path" in self.params:

--- a/trajectorytools/trajectories.py
+++ b/trajectorytools/trajectories.py
@@ -25,7 +25,7 @@ def calculate_center_of_mass(trajectories, params):
 
 
 def estimate_center_and_radius(locations):
-    """ Estimates center and radius of the smallest circle containing all points
+    """Estimates center and radius of the smallest circle containing all points
 
     :param locations: Numpy array of locations. It can be any shape, but last
     dim must be 2 (x, y)
@@ -153,7 +153,7 @@ class Trajectory:
         return tt.geometry.straightness(self.s)
 
     def estimate_center_and_radius_from_locations(self, in_px=False):
-        """ Assumes that the trajectories are restricted to a circular area and
+        """Assumes that the trajectories are restricted to a circular area and
         estimates its center and radius from the trajectories
 
         :param in_px: If True, the results are given in the original
@@ -185,7 +185,7 @@ class Trajectory:
         return factor  # In the future it will return self
 
     def origin_to(self, new_origin):
-        """ Places origin of frame of reference in a given location
+        """Places origin of frame of reference in a given location
 
         :param new_origin: Point that will become our new origin.
         It is expressed in the original frame of reference (usually px).

--- a/trajectorytools/trajectories.py
+++ b/trajectorytools/trajectories.py
@@ -321,13 +321,12 @@ class Trajectories(Trajectory):
         )
 
     @classmethod
-    def from_idtrackerai(cls, trajectories_path, **kwargs):
-        tr = cls.from_idtracker(trajectories_path, **kwargs)
-        tr.params["construct_method"] = "from_idtrackerai"
-        return tr
+    def from_idtracker(cls, trajectories_path, **kwargs):
+        warnings.warn(Warning("Deprecated. Use from_idtrackerai instead"))
+        return cls.from_idtrackerai(trajectories_path, **kwargs)
 
     @classmethod
-    def from_idtracker(cls, trajectories_path, **kwargs):
+    def from_idtrackerai(cls, trajectories_path, **kwargs):
         """Create Trajectories from a idtracker.ai trajectories file
 
         :param trajectories_path: idtracker.ai generated file
@@ -337,7 +336,7 @@ class Trajectories(Trajectory):
         ).item()
         tr = cls.from_idtracker_(traj_dict, **kwargs)
         tr.params["path"] = trajectories_path
-        tr.params["construct_method"] = "from_idtracker"
+        tr.params["construct_method"] = "from_idtrackerai"
         return tr
 
     @classmethod

--- a/trajectorytools/trajectories.py
+++ b/trajectorytools/trajectories.py
@@ -19,7 +19,7 @@ def calculate_center_of_mass(trajectories, params):
     :param params: Dictionary of parameters
     """
     center_of_mass = {
-        k: np.nanmean(trajectories[k], axis=1) for k in Trajectory.keys_to_copy
+        k: np.mean(trajectories[k], axis=1) for k in Trajectory.keys_to_copy
     }
     return CenterMassTrajectory(center_of_mass, params)
 

--- a/trajectorytools/trajectories.py
+++ b/trajectorytools/trajectories.py
@@ -272,6 +272,28 @@ class Trajectories(Trajectory):
         loaded_dict = np.load(filename, allow_pickle=True).item()
         return cls(loaded_dict["traj_data"], loaded_dict["params"])
 
+    def export_trajectories_to_csv(self, csvfilename, delimiter=",", **kwargs):
+        """Export trajectories to a csv plain text file.
+
+        :param csvfilename: Name of the csv file to be created
+        :param delimiter: Delimiter (default is ",")
+        :param kwargs: Other keyword arguments for numpy.savetxt
+        """
+        data_to_save = np.concatenate([self.s, self.v, self.a], axis=-1)
+        data_to_save = data_to_save.reshape(self.number_of_frames, -1)
+        data_header = ["x", "y", "vx", "vy", "ax", "ay"]
+        individuals = range(self.number_of_individuals)
+        header = delimiter.join(
+            [f"{h}_{i}" for i in individuals for h in data_header]
+        )
+        np.savetxt(
+            csvfilename,
+            data_to_save,
+            header=header,
+            delimiter=delimiter,
+            **kwargs,
+        )
+
     def __getitem__(self, val):
         view_trajectories = {
             k: getattr(self, k)[val] for k in self.keys_to_copy


### PR DESCRIPTION
Preparing prerelease of 0.3.3

Changes compared to 0.3.2:
- Export trajectories to csv
- Black version 20.8
- Removing deprecated unused code (average_across_individuals, sum_across_individuals)
- Removing some deprecation warnings (center_trajectories_and_obtain_radius, center_trajectories_and_normalise) because an alternative is not available yet.
- Adding deprecation warnings (Trajectory.orientation_towards)
- Minor refactoring (find_bouts_individual)
- updated README to warn about the two missing frames due to the computation of the velocity and acceleration.
- Deprecation warning from "from_idtracker" (use "from_idtrackerai" instead)
- Compute arena_center if does not exist in "radius_and_center_from_traj_dict"
