### PR TITLE
save smooth_params and interpolate_nans in params dict

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -119,10 +119,11 @@ recorded in de Polavieja Lab (Champalimaud Research, Lisbon)
 ---
 **NOTE**
 
-Note that, due to the computation of velocities and accelerations the
-`traj` object has N-2 frames. By default the missing frames correspond
-to the first and last frames of the video. If you used passed the option
-`"only_past":True` in the `smooth_params`, the missing frames correspond
+Note that, when using constructors like `from_idtrackerai` and `from_positions`, 
+we need to calculate velocity and accelerations from positions. As a result, the
+`traj` object has 2 frames less than the original positions array. By default, the 
+missing frames correspond to the first and last frames of the video. If you used 
+the option `"only_past":True` in `smooth_params`, the missing frames correspond
 to the first two frames of the video.
 
 ---
@@ -152,5 +153,4 @@ If you use this work in an academic context and you want to acknowledge us, plea
 Romero-Ferrero, F., Bergomi, M. G., Hinz, R. C., Heras, F. J., & de Polavieja, G. G. (2019). idtracker.ai: tracking all individuals in small or large collectives of unmarked animals. Nature methods, 1
 
 Heras, F. J., Romero-Ferrero, F., Hinz, R. C., & de Polavieja, G. G. (2019). Deep attention networks reveal the rules of collective motion in zebrafish. PLoS computational biology, 15(9), e1007354.
-
 

--- a/README.rst
+++ b/README.rst
@@ -116,6 +116,16 @@ recorded in de Polavieja Lab (Champalimaud Research, Lisbon)
 .. _directory examples: trajectorytools/examples
 .. _data: trajectorytools/data
 
+---
+**NOTE**
+
+Note that, due to the computation of velocities and accelerations the
+`traj` object has N-2 frames. By default the missing frames correspond
+to the first and last frames of the video. If you used passed the option
+`"only_past":True` in the `smooth_params`, the missing frames correspond
+to the first two frames of the video.
+
+---
 
 Project maintainers
 ===================

--- a/tests/test_trajectories.py
+++ b/tests/test_trajectories.py
@@ -595,10 +595,10 @@ class DownUpResample(DoubleTrajectoriesTestCase):
 
 class ScaleRadiusTrajectoriesTestCase(TrajectoriesTestCase):
     def setUp(self):
-        self.t = Trajectories.from_idtracker(
+        self.t = Trajectories.from_idtrackerai(
             cons.test_trajectories_path, center=True
         ).normalise_by("radius")
-        self.t_normal = Trajectories.from_idtracker(
+        self.t_normal = Trajectories.from_idtrackerai(
             cons.test_trajectories_path
         )
 
@@ -628,10 +628,10 @@ class ScaleRadiusTrajectoriesTestCase(TrajectoriesTestCase):
 
 class TrajectoriesRadiusTestCase(TrajectoriesTestCase):
     def setUp(self):
-        self.t_normal = Trajectories.from_idtracker(
+        self.t_normal = Trajectories.from_idtrackerai(
             cons.test_trajectories_path, smooth_params={"sigma": 1}
         )
-        self.t = Trajectories.from_idtracker(
+        self.t = Trajectories.from_idtrackerai(
             cons.test_trajectories_path, smooth_params={"sigma": 1}
         ).normalise_by("radius")
 

--- a/trajectorytools/trajectories.py
+++ b/trajectorytools/trajectories.py
@@ -322,7 +322,9 @@ class Trajectories(Trajectory):
 
     @classmethod
     def from_idtrackerai(cls, trajectories_path, **kwargs):
-        return cls.from_idtracker(trajectories_path, **kwargs)
+        tr = cls.from_idtracker(trajectories_path, **kwargs)
+        tr.params["construct_method"] = "from_idtrackerai"
+        return tr
 
     @classmethod
     def from_idtracker(cls, trajectories_path, **kwargs):
@@ -335,6 +337,7 @@ class Trajectories(Trajectory):
         ).item()
         tr = cls.from_idtracker_(traj_dict, **kwargs)
         tr.params["path"] = trajectories_path
+        tr.params["construct_method"] = "from_idtracker"
         return tr
 
     @classmethod
@@ -370,6 +373,7 @@ class Trajectories(Trajectory):
 
         traj.params["frame_rate"] = traj_dict.get("frames_per_second", None)
         traj.params["body_length_px"] = traj_dict.get("body_length", None)
+        traj.params["construct_method"] = "from_idtracker_"
         return traj
 
     @classmethod
@@ -409,12 +413,19 @@ class Trajectories(Trajectory):
                 trajectories["_a"],
             ] = tt.velocity_acceleration(t_smooth)
 
+        # TODO: Think to give a hierarchy to the params dictionary
+        # Maybe in the future add a "how_construct" key being a dictionary
+        # with the classmethod called, path, interpolate_nans,
+        # and smooth_params
         params = {
             "displacement": displacement,  # Units: pixels
             "length_unit": 1,  # Units: pixels
             "length_unit_name": "px",
             "time_unit": 1,  # In frames
             "time_unit_name": "frames",
+            "interpolate_nans": interpolate_nans,
+            "smooth_params": smooth_params,
+            "construct_method": "from_positions",
         }
 
         return cls(trajectories, params)

--- a/trajectorytools/trajectories.py
+++ b/trajectorytools/trajectories.py
@@ -413,7 +413,7 @@ class Trajectories(Trajectory):
                 trajectories["_a"],
             ] = tt.velocity_acceleration(t_smooth)
 
-        # TODO: Think to give a hierarchy to the params dictionary
+        # TODO: Organise the params dictionary more hierarchically
         # Maybe in the future add a "how_construct" key being a dictionary
         # with the classmethod called, path, interpolate_nans,
         # and smooth_params

--- a/trajectorytools/trajectories.py
+++ b/trajectorytools/trajectories.py
@@ -321,13 +321,12 @@ class Trajectories(Trajectory):
         )
 
     @classmethod
-    def from_idtrackerai(cls, trajectories_path, **kwargs):
-        tr = cls.from_idtracker(trajectories_path, **kwargs)
-        tr.params["construct_method"] = "from_idtrackerai"
-        return tr
+    def from_idtracker(cls, trajectories_path, **kwargs):
+        warnings.warn(Warning("Deprecated. Use from_idtrackerai instead"))
+        return cls.from_idtrackerai(trajectories_path, **kwargs)
 
     @classmethod
-    def from_idtracker(cls, trajectories_path, **kwargs):
+    def from_idtrackerai(cls, trajectories_path, **kwargs):
         """Create Trajectories from a idtracker.ai trajectories file
 
         :param trajectories_path: idtracker.ai generated file
@@ -337,7 +336,7 @@ class Trajectories(Trajectory):
         ).item()
         tr = cls.from_idtracker_(traj_dict, **kwargs)
         tr.params["path"] = trajectories_path
-        tr.params["construct_method"] = "from_idtracker"
+        tr.params["construct_method"] = "from_idtrackerai"
         return tr
 
     @classmethod


### PR DESCRIPTION
Also: 
- added a comment in the README to warn about the two missing frames due to the computation of the velocity and acceleration.
- Deprecation warning from "from_idtracker" (use "from_idtrackerai" instead)